### PR TITLE
Add greeting GIF reactions for Haru Urara replies

### DIFF
--- a/bot_actions.test.ts
+++ b/bot_actions.test.ts
@@ -14,6 +14,7 @@ import type { AppConfig } from "./src/config.ts";
 import type { BudgetResult, RateLimitResult, UsageStats } from "./src/services/rate_limit.ts";
 import type { LinkOpenError } from "./src/services/link_open.ts";
 import type { SearchResult } from "./src/services/web_search.ts";
+import { aszHaruGreetingGifPool } from "./src/features/reaction_gif.ts";
 
 function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
   return {
@@ -168,18 +169,22 @@ function createDeps(
     },
     rateLimitService: {
       checkUserRateLimit(_userId: string): Promise<RateLimitResult> {
-        return Promise.resolve(overrides.rateLimitResult ?? {
-          allowed: true,
-          remaining: 99,
-          resetInMs: 1000,
-        });
+        return Promise.resolve(
+          overrides.rateLimitResult ?? {
+            allowed: true,
+            remaining: 99,
+            resetInMs: 1000,
+          },
+        );
       },
       recordUserRequest(_userId: string): Promise<void> {
         request_count++;
         return Promise.resolve();
       },
       checkDailyBudget(): Promise<BudgetResult> {
-        return Promise.resolve(overrides.budgetResult ?? { allowed: true, tokensRemaining: 999999 });
+        return Promise.resolve(
+          overrides.budgetResult ?? { allowed: true, tokensRemaining: 999999 },
+        );
       },
       recordTokenUsage(tokens: number): Promise<void> {
         recorded_tokens.push(tokens);
@@ -196,23 +201,27 @@ function createDeps(
     linkOpenService: {
       open(url: string) {
         link_calls.push(url);
-        return Promise.resolve(overrides.linkResult ?? {
-          ok: true,
-          page: {
-            domain: "example.com",
-            title: "Example Title",
-            excerpt: "Example page excerpt",
+        return Promise.resolve(
+          overrides.linkResult ?? {
+            ok: true,
+            page: {
+              domain: "example.com",
+              title: "Example Title",
+              excerpt: "Example page excerpt",
+            },
           },
-        });
+        );
       },
     },
     webSearchService: {
       search(query: string, _maxResults?: number) {
         web_search_calls.push(query);
-        return Promise.resolve(overrides.webSearchResult ?? {
-          ok: true,
-          results: [{ title: "Deno", url: "https://deno.com", snippet: "A runtime" }],
-        });
+        return Promise.resolve(
+          overrides.webSearchResult ?? {
+            ok: true,
+            results: [{ title: "Deno", url: "https://deno.com", snippet: "A runtime" }],
+          },
+        );
       },
     },
   };
@@ -419,6 +428,41 @@ Deno.test("non-open mention still uses auto-search flow", async () => {
       String(web_entry?.["content"] ?? ""),
       'Reference notes for "what is deno?"',
     );
+  } finally {
+    fetch_mock.restore();
+  }
+});
+
+Deno.test("handleMessage posts one greeting GIF when final reply has greeting trigger", async () => {
+  const fetch_mock = mockDiscordApiFetch();
+  try {
+    const config = createMockConfig({ webSearchEnabled: false });
+    const ctx = createDeps(config, {
+      aiResult: { ok: true, text: "Ciallo! Hello there~", tokensUsed: 7 },
+    });
+
+    await handleMessage(createMentionMessage("<@12345> tell me something fun"), ctx.deps);
+
+    assertEquals(fetch_mock.postedMessages.length, 2);
+    assertEquals(fetch_mock.postedMessages[0], "Ciallo! Hello there~");
+    assertEquals(aszHaruGreetingGifPool.includes(fetch_mock.postedMessages[1]), true);
+  } finally {
+    fetch_mock.restore();
+  }
+});
+
+Deno.test("handleMessage does not post greeting GIF when final reply has no greeting trigger", async () => {
+  const fetch_mock = mockDiscordApiFetch();
+  try {
+    const config = createMockConfig({ webSearchEnabled: false });
+    const ctx = createDeps(config, {
+      aiResult: { ok: true, text: "I can help with that request.", tokensUsed: 7 },
+    });
+
+    await handleMessage(createMentionMessage("<@12345> tell me something fun"), ctx.deps);
+
+    assertEquals(fetch_mock.postedMessages.length, 1);
+    assertEquals(fetch_mock.postedMessages[0], "I can help with that request.");
   } finally {
     fetch_mock.restore();
   }

--- a/bot_actions.ts
+++ b/bot_actions.ts
@@ -14,6 +14,7 @@ import {
   szExtractAutoSearchQuery,
   type WebSearchService,
 } from "./src/services/web_search.ts";
+import { szSelectGreetingGifForReply } from "./src/features/reaction_gif.ts";
 
 // Discord API Base URL
 const API_BASE = "https://discord.com/api/v10";
@@ -480,6 +481,15 @@ export async function handleMessage(
   const send_result = await sendMessage(config, channel_id, final_reply);
   if (!send_result.ok) {
     console.error("Failed to send AI reply:", send_result.error);
+    return;
+  }
+
+  const greeting_gif = szSelectGreetingGifForReply(final_reply);
+  if (greeting_gif) {
+    const gif_send_result = await sendMessage(config, channel_id, greeting_gif);
+    if (!gif_send_result.ok) {
+      console.error("Failed to send greeting GIF:", gif_send_result.error);
+    }
   }
 }
 

--- a/src/features/reaction_gif.test.ts
+++ b/src/features/reaction_gif.test.ts
@@ -1,0 +1,47 @@
+import { assertEquals } from "@std/assert";
+import {
+  aszHaruGreetingGifPool,
+  bHasGreetingTrigger,
+  szPickRandomGreetingGif,
+  szSelectGreetingGifForReply,
+} from "./reaction_gif.ts";
+
+Deno.test("bHasGreetingTrigger matches hello/hi/ciallo case-insensitively", () => {
+  assertEquals(bHasGreetingTrigger("Hello there!"), true);
+  assertEquals(bHasGreetingTrigger("hI~"), true);
+  assertEquals(bHasGreetingTrigger("CIALLO!"), true);
+  assertEquals(bHasGreetingTrigger("just saying hi friend"), true);
+});
+
+Deno.test("bHasGreetingTrigger does not match non-greeting text", () => {
+  assertEquals(bHasGreetingTrigger("This is a test."), false);
+  assertEquals(bHasGreetingTrigger("A random message."), false);
+  assertEquals(bHasGreetingTrigger(""), false);
+});
+
+Deno.test("szPickRandomGreetingGif always returns from fixed pool", () => {
+  const samples = [0, 0.15, 0.33, 0.55, 0.79, 0.99, -1, 1, Number.NaN];
+  for (const sample of samples) {
+    const picked = szPickRandomGreetingGif(() => sample);
+    assertEquals(aszHaruGreetingGifPool.includes(picked), true);
+  }
+});
+
+Deno.test("szPickRandomGreetingGif handles edge samples deterministically", () => {
+  assertEquals(szPickRandomGreetingGif(() => 0), aszHaruGreetingGifPool[0]);
+  assertEquals(
+    szPickRandomGreetingGif(() => 0.999999),
+    aszHaruGreetingGifPool[aszHaruGreetingGifPool.length - 1],
+  );
+  assertEquals(
+    szPickRandomGreetingGif(() => 1),
+    aszHaruGreetingGifPool[aszHaruGreetingGifPool.length - 1],
+  );
+  assertEquals(szPickRandomGreetingGif(() => -0.25), aszHaruGreetingGifPool[0]);
+});
+
+Deno.test("szSelectGreetingGifForReply returns gif only for greeting replies", () => {
+  const picked = szSelectGreetingGifForReply("Ciallo there!", () => 0);
+  assertEquals(picked, aszHaruGreetingGifPool[0]);
+  assertEquals(szSelectGreetingGifForReply("No greeting here."), null);
+});

--- a/src/features/reaction_gif.ts
+++ b/src/features/reaction_gif.ts
@@ -1,0 +1,39 @@
+/**
+ * Greeting reaction GIFs for Haru replies.
+ */
+
+export const aszHaruGreetingGifPool: readonly string[] = [
+  "https://tenor.com/view/uma-musume-anime-haru-urara-hi-hello-gif-13117639751450924729",
+  "https://tenor.com/view/haru-urara-umamusume-uma-musume-wave-waving-gif-14802371873246368923",
+  "https://tenor.com/view/haru-urara-gif-21261985",
+  "https://tenor.com/view/umazing-uma-musume-haru-urara-uma-gif-8811229770082296989",
+  "https://tenor.com/view/haru-urara-haru-urara-punch-uma-gif-3671877342466542406",
+];
+
+const GREETING_TRIGGER_RE = /\b(?:hello|hi|ciallo)\b/i;
+
+export function bHasGreetingTrigger(text: string): boolean {
+  if (!text) return false;
+  return GREETING_TRIGGER_RE.test(text);
+}
+
+export function szPickRandomGreetingGif(
+  random: () => number = Math.random,
+): string {
+  const pool_size = aszHaruGreetingGifPool.length;
+  if (pool_size === 0) return "";
+
+  const sample = random();
+  const safe_sample = Number.isFinite(sample) ? sample : 0;
+  const index = Math.max(0, Math.min(pool_size - 1, Math.floor(safe_sample * pool_size)));
+
+  return aszHaruGreetingGifPool[index];
+}
+
+export function szSelectGreetingGifForReply(
+  reply_text: string,
+  random: () => number = Math.random,
+): string | null {
+  if (!bHasGreetingTrigger(reply_text)) return null;
+  return szPickRandomGreetingGif(random);
+}


### PR DESCRIPTION
## Summary
- add greeting reaction GIF support for Haru replies based on final generated text
- detect greeting triggers case-insensitively (`hello`, `hi`, `ciallo`)
- post one additional Discord message with a random URL from the fixed Haru Urara GIF pool
- keep existing mention, AI, Brave auto-search, and `\\open` flows unchanged
- add dedicated unit tests for trigger detection and GIF selection plus bot flow tests for greeting/non-greeting behavior

## Validation
- `deno task check`
- `deno task lint`
- `deno task test` (181 passed, 0 failed)

## Coverage
- `deno test --unstable-kv --allow-env --coverage=<tmp>`
- `deno coverage <tmp>`
- Coverage summary: **Line 96.9%**, **Branch 94.7%** (all files)

Fixes #15
