### PR TITLE
Fix false wellness streaks and scope votes per server

### DIFF
--- a/discord_gateway.ts
+++ b/discord_gateway.ts
@@ -22,7 +22,56 @@ export function startGateway(config: AppConfig, deps: BotDependencies): void {
 
   let ws: WebSocket | null = null;
   let heartbeat_handle: number | undefined;
+  let heartbeat_interval_ms = 45000;
   let seq: number | null = null;
+  let awaiting_heartbeat_ack = false;
+
+  function sendHeartbeat(): void {
+    try {
+      if (!ws || ws.readyState !== WebSocket.OPEN) return;
+
+      if (awaiting_heartbeat_ack) {
+        console.warn("Missed heartbeat ACK, reconnecting gateway");
+        ws.close();
+        return;
+      }
+
+      ws.send(JSON.stringify({ op: 1, d: seq }));
+      awaiting_heartbeat_ack = true;
+    } catch (e) {
+      console.error("Heartbeat error", e);
+    }
+  }
+
+  function startHeartbeatLoop(interval: number): void {
+    heartbeat_interval_ms = interval;
+    awaiting_heartbeat_ack = false;
+
+    if (heartbeat_handle) clearInterval(heartbeat_handle);
+
+    const jitter = Math.random();
+    setTimeout(() => {
+      sendHeartbeat();
+
+      heartbeat_handle = setInterval(() => {
+        sendHeartbeat();
+      }, heartbeat_interval_ms) as unknown as number;
+    }, Math.floor(heartbeat_interval_ms * jitter));
+  }
+
+  function sendOnlinePresence(): void {
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+
+    ws.send(JSON.stringify({
+      op: 3,
+      d: {
+        since: null,
+        activities: [],
+        status: "online",
+        afk: false,
+      },
+    }));
+  }
 
   function vConnect(): void {
     console.log("Connecting to Discord Gateway...");
@@ -43,18 +92,7 @@ export function startGateway(config: AppConfig, deps: BotDependencies): void {
         // Op 10: Hello - start heartbeat and identify
         if (op === 10 && d) {
           const interval = (d["heartbeat_interval"] as number) ?? 45000;
-
-          if (heartbeat_handle) clearInterval(heartbeat_handle);
-
-          heartbeat_handle = setInterval(() => {
-            try {
-              if (ws && ws.readyState === WebSocket.OPEN) {
-                ws.send(JSON.stringify({ op: 1, d: seq }));
-              }
-            } catch (e) {
-              console.error("Heartbeat error", e);
-            }
-          }, interval) as unknown as number;
+          startHeartbeatLoop(interval);
 
           // Send identify payload
           // Intents breakdown:
@@ -73,6 +111,12 @@ export function startGateway(config: AppConfig, deps: BotDependencies): void {
                 browser: "deno",
                 device: "deno",
               },
+              presence: {
+                since: null,
+                activities: [],
+                status: "online",
+                afk: false,
+              },
             },
           };
           ws?.send(JSON.stringify(identify));
@@ -83,6 +127,7 @@ export function startGateway(config: AppConfig, deps: BotDependencies): void {
           const guilds = d["guilds"] as Array<Record<string, unknown>> | undefined;
           console.log(`[GATEWAY] Bot ready as: ${user?.username}#${user?.discriminator} (${user?.id})`);
           console.log(`[GATEWAY] Connected to ${guilds?.length ?? 0} guild(s)`);
+          sendOnlinePresence();
         } else if (op === 0 && t === "GUILD_CREATE" && d) {
           // Log when we receive guild info
           const guild_name = d["name"] as string | undefined;
@@ -90,6 +135,10 @@ export function startGateway(config: AppConfig, deps: BotDependencies): void {
           console.log(`[GATEWAY] Guild available: "${guild_name}" (${guild_id})`);
         } else if (op === 0 && t === "MESSAGE_CREATE" && d) {
           await handleMessage(d as Record<string, unknown>, deps);
+        } else if (op === 1) {
+          sendHeartbeat();
+        } else if (op === 11) {
+          awaiting_heartbeat_ack = false;
         } // Op 9: Invalid session
         else if (op === 9) {
           console.warn("Invalid session, reconnecting");
@@ -103,6 +152,8 @@ export function startGateway(config: AppConfig, deps: BotDependencies): void {
     ws.onclose = (ev: CloseEvent) => {
       console.warn("Gateway socket closed", ev.code, ev.reason);
       if (heartbeat_handle) clearInterval(heartbeat_handle);
+      heartbeat_handle = undefined;
+      awaiting_heartbeat_ack = false;
       // Reconnect after 5 seconds
       setTimeout(vConnect, 5000);
     };

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -81,20 +81,19 @@ export function registerCronJobs(
     console.log("[CRON] Starting wellness check...");
 
     try {
-      const atRisk = await storage.getUsersAtRisk(config.glueAlertThreshold);
+      for (const channelId of config.channelIds) {
+        const atRisk = await storage.getUsersAtRisk(channelId, config.glueAlertThreshold);
 
-      if (atRisk.length === 0) {
-        console.log("[CRON] No users at risk. Everyone is doing okay! 🎉");
-        return;
-      }
+        if (atRisk.length === 0) {
+          console.log(`[CRON] No users at risk in ${channelId}`);
+          continue;
+        }
 
-      console.log(`[CRON] Found ${atRisk.length} user(s) at risk`);
+        console.log(`[CRON] Found ${atRisk.length} user(s) at risk in ${channelId}`);
 
-      for (const userHistory of atRisk) {
-        const user = userHistory[0];
-        const alertEmbed = buildAlertEmbed(user.odUserName, userHistory.length);
-
-        for (const channelId of config.channelIds) {
+        for (const userHistory of atRisk) {
+          const user = userHistory[0];
+          const alertEmbed = buildAlertEmbed(user.odUserName, userHistory.length);
           const response = await discord.postMessage(channelId, alertEmbed);
 
           if (response.ok) {
@@ -122,14 +121,13 @@ export function registerCronJobs(
       const startDate = new Date();
       startDate.setDate(startDate.getDate() - 7);
 
-      const stats = await storage.getStats(
-        startDate.toISOString().split("T")[0],
-        endDate.toISOString().split("T")[0],
-      );
-
-      const embed = buildStatsEmbed(stats, "📊 Weekly Mood Summary");
-
       for (const channelId of config.channelIds) {
+        const stats = await storage.getStats(
+          channelId,
+          startDate.toISOString().split("T")[0],
+          endDate.toISOString().split("T")[0],
+        );
+        const embed = buildStatsEmbed(stats, "📊 Weekly Mood Summary");
         const response = await discord.postMessage(channelId, embed);
 
         if (response.ok) {
@@ -187,7 +185,13 @@ export function registerCronJobs(
             }
 
             for (const voter of answer.voters) {
-              await storage.recordVote(voter.odUserId, voter.odUserName, mood, poll.date);
+              await storage.recordVote(
+                poll.channelId,
+                voter.odUserId,
+                voter.odUserName,
+                mood,
+                poll.date,
+              );
               totalVotes++;
             }
           }

--- a/src/server.ts
+++ b/src/server.ts
@@ -104,16 +104,16 @@ export function createServer(
         const startDate = new Date();
         startDate.setDate(startDate.getDate() - days);
 
-        const stats = await storage.getStats(
-          startDate.toISOString().split("T")[0],
-          endDate.toISOString().split("T")[0],
-        );
-
-        const embed = buildStatsEmbed(stats, `📊 Mood Stats (Last ${days} Days)`);
         const results: string[] = [];
         let successCount = 0;
 
         for (const channelId of config.channelIds) {
+          const stats = await storage.getStats(
+            channelId,
+            startDate.toISOString().split("T")[0],
+            endDate.toISOString().split("T")[0],
+          );
+          const embed = buildStatsEmbed(stats, `📊 Mood Stats (Last ${days} Days)`);
           const response = await discord.postMessage(channelId, embed);
 
           if (response.ok) {
@@ -201,7 +201,13 @@ export function createServer(
             if (!mood) continue;
 
             for (const voter of answer.voters) {
-              await storage.recordVote(voter.odUserId, voter.odUserName, mood, poll.date);
+              await storage.recordVote(
+                poll.channelId,
+                voter.odUserId,
+                voter.odUserName,
+                mood,
+                poll.date,
+              );
               pollVotes++;
             }
           }
@@ -229,6 +235,7 @@ export function createServer(
 
     // Record a vote (for testing)
     if (url.pathname === "/vote") {
+      const channelId = url.searchParams.get("channelId") ?? config.channelId;
       const userId = url.searchParams.get("user");
       const userName = url.searchParams.get("name") ?? "TestUser";
       const mood = url.searchParams.get("mood") as Mood | null;
@@ -236,8 +243,8 @@ export function createServer(
 
       if (!userId || !mood) {
         return new Response(
-          "Missing required params: user, mood. Optional: name, date\n" +
-            "Example: /vote?user=123&mood=glue&name=Alice&date=2025-12-11",
+          "Missing required params: user, mood. Optional: name, date, channelId\n" +
+            "Example: /vote?user=123&mood=glue&name=Alice&date=2025-12-11&channelId=123456789",
           { status: 400 },
         );
       }
@@ -247,9 +254,13 @@ export function createServer(
       }
 
       try {
-        await storage.recordVote(userId, userName, mood, date);
-        console.log(`[SERVER] Recorded vote: ${userName} (${userId}) = ${mood} on ${date}`);
-        return new Response(`✅ Vote recorded: ${userName} = ${mood} on ${date}`);
+        await storage.recordVote(channelId, userId, userName, mood, date);
+        console.log(
+          `[SERVER] Recorded vote in ${channelId}: ${userName} (${userId}) = ${mood} on ${date}`,
+        );
+        return new Response(
+          `✅ Vote recorded in ${channelId}: ${userName} = ${mood} on ${date}`,
+        );
       } catch (error) {
         console.error("[SERVER] Error recording vote:", error);
         return new Response(`❌ Error: ${error}`, { status: 500 });
@@ -258,6 +269,7 @@ export function createServer(
 
     // Get stats as JSON (without posting)
     if (url.pathname === "/stats") {
+      const channelId = url.searchParams.get("channelId") ?? config.channelId;
       const days = parseInt(url.searchParams.get("days") ?? "7", 10);
 
       try {
@@ -266,13 +278,14 @@ export function createServer(
         startDate.setDate(startDate.getDate() - days);
 
         const stats = await storage.getStats(
+          channelId,
           startDate.toISOString().split("T")[0],
           endDate.toISOString().split("T")[0],
         );
 
         const embed = buildStatsEmbed(stats, `📊 Mood Stats (Last ${days} Days)`);
 
-        return new Response(JSON.stringify({ stats, embed }, null, 2), {
+        return new Response(JSON.stringify({ channelId, stats, embed }, null, 2), {
           headers: { "Content-Type": "application/json" },
         });
       } catch (error) {
@@ -284,19 +297,25 @@ export function createServer(
     // Check for users at risk (without sending alerts)
     if (url.pathname === "/check-alerts") {
       try {
-        const atRisk = await storage.getUsersAtRisk(config.glueAlertThreshold);
+        const results = [];
 
-        if (atRisk.length === 0) {
+        for (const channelId of config.channelIds) {
+          const atRisk = await storage.getUsersAtRisk(channelId, config.glueAlertThreshold);
+          results.push({
+            channelId,
+            usersAtRisk: atRisk.map((userHistory) => ({
+              user: userHistory[0].odUserName,
+              odUserId: userHistory[0].odUserId,
+              consecutiveDays: userHistory.length,
+            })),
+          });
+        }
+
+        if (results.every((entry) => entry.usersAtRisk.length === 0)) {
           return new Response("✅ No users at risk. Everyone is doing okay! 🎉");
         }
 
-        const results = atRisk.map((userHistory) => ({
-          user: userHistory[0].odUserName,
-          odUserId: userHistory[0].odUserId,
-          consecutiveDays: userHistory.length,
-        }));
-
-        return new Response(JSON.stringify({ usersAtRisk: results }, null, 2), {
+        return new Response(JSON.stringify({ results }, null, 2), {
           headers: { "Content-Type": "application/json" },
         });
       } catch (error) {
@@ -307,20 +326,24 @@ export function createServer(
 
     // Get user history
     if (url.pathname === "/user-history") {
+      const channelId = url.searchParams.get("channelId") ?? config.channelId;
       const userId = url.searchParams.get("user");
 
       if (!userId) {
-        return new Response("Missing required param: user\nExample: /user-history?user=123", {
-          status: 400,
-        });
+        return new Response(
+          "Missing required param: user\nExample: /user-history?user=123&channelId=123456789",
+          {
+            status: 400,
+          },
+        );
       }
 
       try {
-        const history = await storage.getUserHistory(userId);
-        const consecutiveGlue = await storage.getConsecutiveGlueCount(userId);
+        const history = await storage.getUserHistory(channelId, userId);
+        const consecutiveGlue = await storage.getConsecutiveGlueCount(channelId, userId);
 
         return new Response(
-          JSON.stringify({ userId, consecutiveGlue, history }, null, 2),
+          JSON.stringify({ channelId, userId, consecutiveGlue, history }, null, 2),
           { headers: { "Content-Type": "application/json" } },
         );
       } catch (error) {
@@ -447,9 +470,9 @@ TRIGGER ENDPOINTS (post to Discord)
 DATA ENDPOINTS (view/modify data)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   /vote?user=ID&mood=MOOD   Record a vote
-  /stats?days=7             View stats as JSON
+  /stats?days=7             View channel stats as JSON
   /check-alerts             Check who's at risk
-  /user-history?user=ID     View user history
+  /user-history?user=ID     View channel-scoped user history
   /pending-polls            View polls awaiting collection
   /add-pending-poll?...     Add a poll for testing
 

--- a/src/services/storage.test.ts
+++ b/src/services/storage.test.ts
@@ -238,6 +238,31 @@ Deno.test("getConsecutiveGlueCount stops at first non-glue vote", async () => {
   kv.close();
 });
 
+Deno.test("getConsecutiveGlueCount stops when there is a gap in vote dates", async () => {
+  const { storage, kv } = await createTestStorage();
+
+  await storage.recordVote("user123", "Alice", "glue", "2025-12-05");
+  await storage.recordVote("user123", "Alice", "glue", "2025-12-07");
+  await storage.recordVote("user123", "Alice", "glue", "2025-12-08");
+
+  const count = await storage.getConsecutiveGlueCount("user123");
+  assertEquals(count, 2); // 12-06 is missing, so 12-05 does not extend the streak
+
+  kv.close();
+});
+
+Deno.test("getConsecutiveGlueCount returns 1 when most recent glue vote is stale", async () => {
+  const { storage, kv } = await createTestStorage();
+
+  await storage.recordVote("user123", "Alice", "glue", "2025-12-01");
+  await storage.recordVote("user123", "Alice", "glue", "2025-12-03");
+
+  const count = await storage.getConsecutiveGlueCount("user123");
+  assertEquals(count, 1);
+
+  kv.close();
+});
+
 // ============================================================================
 // getUsersAtRisk Tests
 // ============================================================================
@@ -309,6 +334,20 @@ Deno.test("getUsersAtRisk identifies multiple users at risk", async () => {
 
   const atRisk = await storage.getUsersAtRisk(7);
   assertEquals(atRisk.length, 2);
+
+  kv.close();
+});
+
+Deno.test("getUsersAtRisk excludes users whose glue votes are not on consecutive days", async () => {
+  const { storage, kv } = await createTestStorage();
+
+  await storage.recordVote("user123", "Alice", "glue", "2025-12-01");
+  await storage.recordVote("user123", "Alice", "glue", "2025-12-03");
+  await storage.recordVote("user123", "Alice", "glue", "2025-12-04");
+  await storage.recordVote("user123", "Alice", "glue", "2025-12-05");
+
+  const atRisk = await storage.getUsersAtRisk(4);
+  assertEquals(atRisk, []);
 
   kv.close();
 });

--- a/src/services/storage.test.ts
+++ b/src/services/storage.test.ts
@@ -8,6 +8,9 @@ import { assertEquals } from "@std/assert";
 import { createStorageService, type StorageService } from "./storage.ts";
 import type { PollRecord } from "../types/storage.ts";
 
+const TEST_CHANNEL_ID = "chan-1";
+const OTHER_CHANNEL_ID = "chan-2";
+
 // Helper to create a fresh storage service for each test
 async function createTestStorage(): Promise<{ storage: StorageService; kv: Deno.Kv }> {
   const kv = await Deno.openKv(":memory:");
@@ -22,10 +25,11 @@ async function createTestStorage(): Promise<{ storage: StorageService; kv: Deno.
 Deno.test("recordVote stores a vote correctly", async () => {
   const { storage, kv } = await createTestStorage();
 
-  await storage.recordVote("user123", "Alice", "umazing", "2025-12-10");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "umazing", "2025-12-10");
 
-  const votes = await storage.getVotesForDate("2025-12-10");
+  const votes = await storage.getVotesForDate(TEST_CHANNEL_ID, "2025-12-10");
   assertEquals(votes.length, 1);
+  assertEquals(votes[0].channelId, TEST_CHANNEL_ID);
   assertEquals(votes[0].odUserId, "user123");
   assertEquals(votes[0].odUserName, "Alice");
   assertEquals(votes[0].mood, "umazing");
@@ -37,10 +41,10 @@ Deno.test("recordVote stores a vote correctly", async () => {
 Deno.test("recordVote overwrites vote for same user on same date", async () => {
   const { storage, kv } = await createTestStorage();
 
-  await storage.recordVote("user123", "Alice", "umazing", "2025-12-10");
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-10");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "umazing", "2025-12-10");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-10");
 
-  const votes = await storage.getVotesForDate("2025-12-10");
+  const votes = await storage.getVotesForDate(TEST_CHANNEL_ID, "2025-12-10");
   assertEquals(votes.length, 1);
   assertEquals(votes[0].mood, "glue"); // Should be updated
 
@@ -50,12 +54,29 @@ Deno.test("recordVote overwrites vote for same user on same date", async () => {
 Deno.test("recordVote stores multiple users on same date", async () => {
   const { storage, kv } = await createTestStorage();
 
-  await storage.recordVote("user1", "Alice", "umazing", "2025-12-10");
-  await storage.recordVote("user2", "Bob", "ok", "2025-12-10");
-  await storage.recordVote("user3", "Charlie", "glue", "2025-12-10");
+  await storage.recordVote(TEST_CHANNEL_ID, "user1", "Alice", "umazing", "2025-12-10");
+  await storage.recordVote(TEST_CHANNEL_ID, "user2", "Bob", "ok", "2025-12-10");
+  await storage.recordVote(TEST_CHANNEL_ID, "user3", "Charlie", "glue", "2025-12-10");
 
-  const votes = await storage.getVotesForDate("2025-12-10");
+  const votes = await storage.getVotesForDate(TEST_CHANNEL_ID, "2025-12-10");
   assertEquals(votes.length, 3);
+
+  kv.close();
+});
+
+Deno.test("recordVote isolates same user across channels", async () => {
+  const { storage, kv } = await createTestStorage();
+
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-10");
+  await storage.recordVote(OTHER_CHANNEL_ID, "user123", "Alice", "ok", "2025-12-10");
+
+  const firstChannelVotes = await storage.getVotesForDate(TEST_CHANNEL_ID, "2025-12-10");
+  const secondChannelVotes = await storage.getVotesForDate(OTHER_CHANNEL_ID, "2025-12-10");
+
+  assertEquals(firstChannelVotes.length, 1);
+  assertEquals(firstChannelVotes[0].mood, "glue");
+  assertEquals(secondChannelVotes.length, 1);
+  assertEquals(secondChannelVotes[0].mood, "ok");
 
   kv.close();
 });
@@ -67,7 +88,7 @@ Deno.test("recordVote stores multiple users on same date", async () => {
 Deno.test("getUserHistory returns empty array for unknown user", async () => {
   const { storage, kv } = await createTestStorage();
 
-  const history = await storage.getUserHistory("unknown");
+  const history = await storage.getUserHistory(TEST_CHANNEL_ID, "unknown");
   assertEquals(history, []);
 
   kv.close();
@@ -76,11 +97,11 @@ Deno.test("getUserHistory returns empty array for unknown user", async () => {
 Deno.test("getUserHistory returns votes sorted by date descending", async () => {
   const { storage, kv } = await createTestStorage();
 
-  await storage.recordVote("user123", "Alice", "umazing", "2025-12-08");
-  await storage.recordVote("user123", "Alice", "ok", "2025-12-10");
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-09");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "umazing", "2025-12-08");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "ok", "2025-12-10");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-09");
 
-  const history = await storage.getUserHistory("user123");
+  const history = await storage.getUserHistory(TEST_CHANNEL_ID, "user123");
 
   assertEquals(history.length, 3);
   assertEquals(history[0].date, "2025-12-10"); // Most recent first
@@ -96,10 +117,10 @@ Deno.test("getUserHistory respects limit parameter", async () => {
   // Add 10 votes
   for (let i = 1; i <= 10; i++) {
     const date = `2025-12-${i.toString().padStart(2, "0")}`;
-    await storage.recordVote("user123", "Alice", "ok", date);
+    await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "ok", date);
   }
 
-  const history = await storage.getUserHistory("user123", 5);
+  const history = await storage.getUserHistory(TEST_CHANNEL_ID, "user123", 5);
   assertEquals(history.length, 5);
 
   kv.close();
@@ -112,7 +133,7 @@ Deno.test("getUserHistory respects limit parameter", async () => {
 Deno.test("getVotesForDate returns empty array for date with no votes", async () => {
   const { storage, kv } = await createTestStorage();
 
-  const votes = await storage.getVotesForDate("2025-12-10");
+  const votes = await storage.getVotesForDate(TEST_CHANNEL_ID, "2025-12-10");
   assertEquals(votes, []);
 
   kv.close();
@@ -121,11 +142,11 @@ Deno.test("getVotesForDate returns empty array for date with no votes", async ()
 Deno.test("getVotesForDate returns all votes for a specific date", async () => {
   const { storage, kv } = await createTestStorage();
 
-  await storage.recordVote("user1", "Alice", "umazing", "2025-12-10");
-  await storage.recordVote("user2", "Bob", "ok", "2025-12-10");
-  await storage.recordVote("user3", "Charlie", "glue", "2025-12-11"); // Different date
+  await storage.recordVote(TEST_CHANNEL_ID, "user1", "Alice", "umazing", "2025-12-10");
+  await storage.recordVote(TEST_CHANNEL_ID, "user2", "Bob", "ok", "2025-12-10");
+  await storage.recordVote(TEST_CHANNEL_ID, "user3", "Charlie", "glue", "2025-12-11"); // Different date
 
-  const votes = await storage.getVotesForDate("2025-12-10");
+  const votes = await storage.getVotesForDate(TEST_CHANNEL_ID, "2025-12-10");
   assertEquals(votes.length, 2);
 
   kv.close();
@@ -138,7 +159,7 @@ Deno.test("getVotesForDate returns all votes for a specific date", async () => {
 Deno.test("getStats returns empty stats for date range with no votes", async () => {
   const { storage, kv } = await createTestStorage();
 
-  const stats = await storage.getStats("2025-12-01", "2025-12-03");
+  const stats = await storage.getStats(TEST_CHANNEL_ID, "2025-12-01", "2025-12-03");
 
   assertEquals(stats.length, 3);
   assertEquals(stats[0].total, 0);
@@ -151,12 +172,12 @@ Deno.test("getStats returns empty stats for date range with no votes", async () 
 Deno.test("getStats aggregates votes correctly", async () => {
   const { storage, kv } = await createTestStorage();
 
-  await storage.recordVote("user1", "Alice", "umazing", "2025-12-10");
-  await storage.recordVote("user2", "Bob", "umazing", "2025-12-10");
-  await storage.recordVote("user3", "Charlie", "ok", "2025-12-10");
-  await storage.recordVote("user4", "Diana", "glue", "2025-12-10");
+  await storage.recordVote(TEST_CHANNEL_ID, "user1", "Alice", "umazing", "2025-12-10");
+  await storage.recordVote(TEST_CHANNEL_ID, "user2", "Bob", "umazing", "2025-12-10");
+  await storage.recordVote(TEST_CHANNEL_ID, "user3", "Charlie", "ok", "2025-12-10");
+  await storage.recordVote(TEST_CHANNEL_ID, "user4", "Diana", "glue", "2025-12-10");
 
-  const stats = await storage.getStats("2025-12-10", "2025-12-10");
+  const stats = await storage.getStats(TEST_CHANNEL_ID, "2025-12-10", "2025-12-10");
 
   assertEquals(stats.length, 1);
   assertEquals(stats[0].umazing, 2);
@@ -170,16 +191,37 @@ Deno.test("getStats aggregates votes correctly", async () => {
 Deno.test("getStats returns stats sorted by date ascending", async () => {
   const { storage, kv } = await createTestStorage();
 
-  await storage.recordVote("user1", "Alice", "umazing", "2025-12-12");
-  await storage.recordVote("user1", "Alice", "ok", "2025-12-10");
-  await storage.recordVote("user1", "Alice", "glue", "2025-12-11");
+  await storage.recordVote(TEST_CHANNEL_ID, "user1", "Alice", "umazing", "2025-12-12");
+  await storage.recordVote(TEST_CHANNEL_ID, "user1", "Alice", "ok", "2025-12-10");
+  await storage.recordVote(TEST_CHANNEL_ID, "user1", "Alice", "glue", "2025-12-11");
 
-  const stats = await storage.getStats("2025-12-10", "2025-12-12");
+  const stats = await storage.getStats(TEST_CHANNEL_ID, "2025-12-10", "2025-12-12");
 
   assertEquals(stats.length, 3);
   assertEquals(stats[0].date, "2025-12-10");
   assertEquals(stats[1].date, "2025-12-11");
   assertEquals(stats[2].date, "2025-12-12");
+
+  kv.close();
+});
+
+Deno.test("getStats isolates channels", async () => {
+  const { storage, kv } = await createTestStorage();
+
+  await storage.recordVote(TEST_CHANNEL_ID, "user1", "Alice", "glue", "2025-12-10");
+  await storage.recordVote(OTHER_CHANNEL_ID, "user1", "Alice", "umazing", "2025-12-10");
+
+  const firstChannelStats = await storage.getStats(TEST_CHANNEL_ID, "2025-12-10", "2025-12-10");
+  const secondChannelStats = await storage.getStats(
+    OTHER_CHANNEL_ID,
+    "2025-12-10",
+    "2025-12-10",
+  );
+
+  assertEquals(firstChannelStats[0].glue, 1);
+  assertEquals(firstChannelStats[0].umazing, 0);
+  assertEquals(secondChannelStats[0].glue, 0);
+  assertEquals(secondChannelStats[0].umazing, 1);
 
   kv.close();
 });
@@ -191,7 +233,7 @@ Deno.test("getStats returns stats sorted by date ascending", async () => {
 Deno.test("getConsecutiveGlueCount returns 0 for user with no votes", async () => {
   const { storage, kv } = await createTestStorage();
 
-  const count = await storage.getConsecutiveGlueCount("unknown");
+  const count = await storage.getConsecutiveGlueCount(TEST_CHANNEL_ID, "unknown");
   assertEquals(count, 0);
 
   kv.close();
@@ -200,11 +242,11 @@ Deno.test("getConsecutiveGlueCount returns 0 for user with no votes", async () =
 Deno.test("getConsecutiveGlueCount returns 0 when most recent is not glue", async () => {
   const { storage, kv } = await createTestStorage();
 
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-08");
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-09");
-  await storage.recordVote("user123", "Alice", "ok", "2025-12-10"); // Most recent
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-08");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-09");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "ok", "2025-12-10"); // Most recent
 
-  const count = await storage.getConsecutiveGlueCount("user123");
+  const count = await storage.getConsecutiveGlueCount(TEST_CHANNEL_ID, "user123");
   assertEquals(count, 0);
 
   kv.close();
@@ -213,12 +255,12 @@ Deno.test("getConsecutiveGlueCount returns 0 when most recent is not glue", asyn
 Deno.test("getConsecutiveGlueCount counts consecutive glue votes from most recent", async () => {
   const { storage, kv } = await createTestStorage();
 
-  await storage.recordVote("user123", "Alice", "umazing", "2025-12-05");
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-06");
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-07");
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-08");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "umazing", "2025-12-05");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-06");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-07");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-08");
 
-  const count = await storage.getConsecutiveGlueCount("user123");
+  const count = await storage.getConsecutiveGlueCount(TEST_CHANNEL_ID, "user123");
   assertEquals(count, 3); // 3 consecutive glue days
 
   kv.close();
@@ -227,12 +269,12 @@ Deno.test("getConsecutiveGlueCount counts consecutive glue votes from most recen
 Deno.test("getConsecutiveGlueCount stops at first non-glue vote", async () => {
   const { storage, kv } = await createTestStorage();
 
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-05");
-  await storage.recordVote("user123", "Alice", "ok", "2025-12-06"); // Breaks streak
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-07");
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-08");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-05");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "ok", "2025-12-06"); // Breaks streak
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-07");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-08");
 
-  const count = await storage.getConsecutiveGlueCount("user123");
+  const count = await storage.getConsecutiveGlueCount(TEST_CHANNEL_ID, "user123");
   assertEquals(count, 2); // Only 2 consecutive from most recent
 
   kv.close();
@@ -241,11 +283,11 @@ Deno.test("getConsecutiveGlueCount stops at first non-glue vote", async () => {
 Deno.test("getConsecutiveGlueCount stops when there is a gap in vote dates", async () => {
   const { storage, kv } = await createTestStorage();
 
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-05");
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-07");
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-08");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-05");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-07");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-08");
 
-  const count = await storage.getConsecutiveGlueCount("user123");
+  const count = await storage.getConsecutiveGlueCount(TEST_CHANNEL_ID, "user123");
   assertEquals(count, 2); // 12-06 is missing, so 12-05 does not extend the streak
 
   kv.close();
@@ -254,11 +296,27 @@ Deno.test("getConsecutiveGlueCount stops when there is a gap in vote dates", asy
 Deno.test("getConsecutiveGlueCount returns 1 when most recent glue vote is stale", async () => {
   const { storage, kv } = await createTestStorage();
 
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-01");
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-03");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-01");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-03");
 
-  const count = await storage.getConsecutiveGlueCount("user123");
+  const count = await storage.getConsecutiveGlueCount(TEST_CHANNEL_ID, "user123");
   assertEquals(count, 1);
+
+  kv.close();
+});
+
+Deno.test("getConsecutiveGlueCount is channel scoped", async () => {
+  const { storage, kv } = await createTestStorage();
+
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-07");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-08");
+  await storage.recordVote(OTHER_CHANNEL_ID, "user123", "Alice", "ok", "2025-12-08");
+
+  const firstChannelCount = await storage.getConsecutiveGlueCount(TEST_CHANNEL_ID, "user123");
+  const secondChannelCount = await storage.getConsecutiveGlueCount(OTHER_CHANNEL_ID, "user123");
+
+  assertEquals(firstChannelCount, 2);
+  assertEquals(secondChannelCount, 0);
 
   kv.close();
 });
@@ -270,9 +328,9 @@ Deno.test("getConsecutiveGlueCount returns 1 when most recent glue vote is stale
 Deno.test("getUsersAtRisk returns empty array when no users at risk", async () => {
   const { storage, kv } = await createTestStorage();
 
-  await storage.recordVote("user123", "Alice", "umazing", "2025-12-10");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "umazing", "2025-12-10");
 
-  const atRisk = await storage.getUsersAtRisk(7);
+  const atRisk = await storage.getUsersAtRisk(TEST_CHANNEL_ID, 7);
   assertEquals(atRisk, []);
 
   kv.close();
@@ -284,10 +342,10 @@ Deno.test("getUsersAtRisk identifies user at threshold", async () => {
   // Create 7 consecutive glue days for user
   for (let i = 1; i <= 7; i++) {
     const date = `2025-12-${i.toString().padStart(2, "0")}`;
-    await storage.recordVote("user123", "Alice", "glue", date);
+    await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", date);
   }
 
-  const atRisk = await storage.getUsersAtRisk(7);
+  const atRisk = await storage.getUsersAtRisk(TEST_CHANNEL_ID, 7);
   assertEquals(atRisk.length, 1);
   assertEquals(atRisk[0][0].odUserId, "user123");
 
@@ -300,10 +358,10 @@ Deno.test("getUsersAtRisk does not include users below threshold", async () => {
   // Create only 5 consecutive glue days
   for (let i = 1; i <= 5; i++) {
     const date = `2025-12-${i.toString().padStart(2, "0")}`;
-    await storage.recordVote("user123", "Alice", "glue", date);
+    await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", date);
   }
 
-  const atRisk = await storage.getUsersAtRisk(7);
+  const atRisk = await storage.getUsersAtRisk(TEST_CHANNEL_ID, 7);
   assertEquals(atRisk, []);
 
   kv.close();
@@ -314,17 +372,30 @@ Deno.test("getUsersAtRisk identifies multiple users at risk", async () => {
 
   // User 1: 7 glue days
   for (let i = 1; i <= 7; i++) {
-    await storage.recordVote("user1", "Alice", "glue", `2025-12-${i.toString().padStart(2, "0")}`);
+    await storage.recordVote(
+      TEST_CHANNEL_ID,
+      "user1",
+      "Alice",
+      "glue",
+      `2025-12-${i.toString().padStart(2, "0")}`,
+    );
   }
 
   // User 2: 8 glue days
   for (let i = 1; i <= 8; i++) {
-    await storage.recordVote("user2", "Bob", "glue", `2025-12-${i.toString().padStart(2, "0")}`);
+    await storage.recordVote(
+      TEST_CHANNEL_ID,
+      "user2",
+      "Bob",
+      "glue",
+      `2025-12-${i.toString().padStart(2, "0")}`,
+    );
   }
 
   // User 3: Only 3 glue days (not at risk)
   for (let i = 1; i <= 3; i++) {
     await storage.recordVote(
+      TEST_CHANNEL_ID,
       "user3",
       "Charlie",
       "glue",
@@ -332,7 +403,7 @@ Deno.test("getUsersAtRisk identifies multiple users at risk", async () => {
     );
   }
 
-  const atRisk = await storage.getUsersAtRisk(7);
+  const atRisk = await storage.getUsersAtRisk(TEST_CHANNEL_ID, 7);
   assertEquals(atRisk.length, 2);
 
   kv.close();
@@ -341,13 +412,31 @@ Deno.test("getUsersAtRisk identifies multiple users at risk", async () => {
 Deno.test("getUsersAtRisk excludes users whose glue votes are not on consecutive days", async () => {
   const { storage, kv } = await createTestStorage();
 
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-01");
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-03");
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-04");
-  await storage.recordVote("user123", "Alice", "glue", "2025-12-05");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-01");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-03");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-04");
+  await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", "2025-12-05");
 
-  const atRisk = await storage.getUsersAtRisk(4);
+  const atRisk = await storage.getUsersAtRisk(TEST_CHANNEL_ID, 4);
   assertEquals(atRisk, []);
+
+  kv.close();
+});
+
+Deno.test("getUsersAtRisk is channel scoped", async () => {
+  const { storage, kv } = await createTestStorage();
+
+  for (let i = 1; i <= 7; i++) {
+    const date = `2025-12-${i.toString().padStart(2, "0")}`;
+    await storage.recordVote(TEST_CHANNEL_ID, "user123", "Alice", "glue", date);
+    await storage.recordVote(OTHER_CHANNEL_ID, "user123", "Alice", "ok", date);
+  }
+
+  const firstChannelAtRisk = await storage.getUsersAtRisk(TEST_CHANNEL_ID, 7);
+  const secondChannelAtRisk = await storage.getUsersAtRisk(OTHER_CHANNEL_ID, 7);
+
+  assertEquals(firstChannelAtRisk.length, 1);
+  assertEquals(secondChannelAtRisk, []);
 
   kv.close();
 });

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -50,6 +50,13 @@ export interface StorageService {
  * Creates a storage service backed by Deno KV.
  */
 export function createStorageService(kv: Deno.Kv): StorageService {
+  const getPreviousDate = (date: string): string => {
+    const [year, month, day] = date.split("-").map(Number);
+    const value = new Date(Date.UTC(year, month - 1, day));
+    value.setUTCDate(value.getUTCDate() - 1);
+    return value.toISOString().split("T")[0];
+  };
+
   return {
     async recordVote(userId, userName, mood, date) {
       const record: VoteRecord = {
@@ -134,14 +141,20 @@ export function createStorageService(kv: Deno.Kv): StorageService {
 
     async getConsecutiveGlueCount(userId) {
       const history = await this.getUserHistory(userId, 30);
-      let count = 0;
+      if (history.length === 0 || history[0].mood !== "glue") {
+        return 0;
+      }
 
-      for (const record of history) {
-        if (record.mood === "glue") {
-          count++;
-        } else {
-          break; // Stop at first non-glue
+      let count = 1;
+      let expectedDate = getPreviousDate(history[0].date);
+
+      for (const record of history.slice(1)) {
+        if (record.mood !== "glue" || record.date !== expectedDate) {
+          break;
         }
+
+        count++;
+        expectedDate = getPreviousDate(record.date);
       }
 
       return count;
@@ -161,7 +174,7 @@ export function createStorageService(kv: Deno.Kv): StorageService {
       for (const userId of userIds) {
         const count = await this.getConsecutiveGlueCount(userId);
         if (count >= threshold) {
-          const history = await this.getUserHistory(userId, threshold);
+          const history = await this.getUserHistory(userId, count);
           atRisk.push(history);
         }
       }

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -12,6 +12,7 @@ import type { DailyStats, PollRecord, VoteRecord } from "../types/storage.ts";
 export interface StorageService {
   /** Record a user's vote */
   recordVote(
+    channelId: string,
     userId: string,
     userName: string,
     mood: Mood,
@@ -19,19 +20,19 @@ export interface StorageService {
   ): Promise<void>;
 
   /** Get a user's vote history (most recent first) */
-  getUserHistory(userId: string, limit?: number): Promise<VoteRecord[]>;
+  getUserHistory(channelId: string, userId: string, limit?: number): Promise<VoteRecord[]>;
 
   /** Get aggregated stats for a date range */
-  getStats(startDate: string, endDate: string): Promise<DailyStats[]>;
+  getStats(channelId: string, startDate: string, endDate: string): Promise<DailyStats[]>;
 
   /** Get all votes for a specific date */
-  getVotesForDate(date: string): Promise<VoteRecord[]>;
+  getVotesForDate(channelId: string, date: string): Promise<VoteRecord[]>;
 
   /** Check if a user has consecutive "glue" votes */
-  getConsecutiveGlueCount(userId: string): Promise<number>;
+  getConsecutiveGlueCount(channelId: string, userId: string): Promise<number>;
 
   /** Get all users who have hit the glue threshold */
-  getUsersAtRisk(threshold: number): Promise<VoteRecord[][]>;
+  getUsersAtRisk(channelId: string, threshold: number): Promise<VoteRecord[][]>;
 
   /** Save a pending poll for later result collection */
   savePendingPoll(poll: PollRecord): Promise<void>;
@@ -58,8 +59,9 @@ export function createStorageService(kv: Deno.Kv): StorageService {
   };
 
   return {
-    async recordVote(userId, userName, mood, date) {
+    async recordVote(channelId, userId, userName, mood, date) {
       const record: VoteRecord = {
+        channelId,
         odUserId: userId,
         odUserName: userName,
         mood,
@@ -68,16 +70,16 @@ export function createStorageService(kv: Deno.Kv): StorageService {
       };
 
       // Store by date and user (for daily lookups)
-      await kv.set(["votes", date, userId], record);
+      await kv.set(["votes", channelId, date, userId], record);
 
       // Store in user's history (for consecutive checks)
-      await kv.set(["user_votes", userId, date], record);
+      await kv.set(["user_votes", channelId, userId, date], record);
     },
 
-    async getUserHistory(userId, limit = 30) {
+    async getUserHistory(channelId, userId, limit = 30) {
       const records: VoteRecord[] = [];
       const iter = kv.list<VoteRecord>({
-        prefix: ["user_votes", userId],
+        prefix: ["user_votes", channelId, userId],
       });
 
       for await (const entry of iter) {
@@ -90,10 +92,10 @@ export function createStorageService(kv: Deno.Kv): StorageService {
       return records.slice(0, limit);
     },
 
-    async getVotesForDate(date) {
+    async getVotesForDate(channelId, date) {
       const records: VoteRecord[] = [];
       const iter = kv.list<VoteRecord>({
-        prefix: ["votes", date],
+        prefix: ["votes", channelId, date],
       });
 
       for await (const entry of iter) {
@@ -103,7 +105,7 @@ export function createStorageService(kv: Deno.Kv): StorageService {
       return records;
     },
 
-    async getStats(startDate, endDate) {
+    async getStats(channelId, startDate, endDate) {
       const statsMap = new Map<string, DailyStats>();
 
       // Initialize all dates in range
@@ -123,7 +125,7 @@ export function createStorageService(kv: Deno.Kv): StorageService {
       }
 
       // Aggregate votes
-      const iter = kv.list<VoteRecord>({ prefix: ["votes"] });
+      const iter = kv.list<VoteRecord>({ prefix: ["votes", channelId] });
       for await (const entry of iter) {
         const record = entry.value;
         if (record.date >= startDate && record.date <= endDate) {
@@ -139,8 +141,8 @@ export function createStorageService(kv: Deno.Kv): StorageService {
       return Array.from(statsMap.values()).sort((a, b) => a.date.localeCompare(b.date));
     },
 
-    async getConsecutiveGlueCount(userId) {
-      const history = await this.getUserHistory(userId, 30);
+    async getConsecutiveGlueCount(channelId, userId) {
+      const history = await this.getUserHistory(channelId, userId, 30);
       if (history.length === 0 || history[0].mood !== "glue") {
         return 0;
       }
@@ -160,10 +162,10 @@ export function createStorageService(kv: Deno.Kv): StorageService {
       return count;
     },
 
-    async getUsersAtRisk(threshold) {
+    async getUsersAtRisk(channelId, threshold) {
       // Get all unique user IDs
       const userIds = new Set<string>();
-      const iter = kv.list<VoteRecord>({ prefix: ["user_votes"] });
+      const iter = kv.list<VoteRecord>({ prefix: ["user_votes", channelId] });
 
       for await (const entry of iter) {
         userIds.add(entry.value.odUserId);
@@ -172,9 +174,9 @@ export function createStorageService(kv: Deno.Kv): StorageService {
       // Check each user
       const atRisk: VoteRecord[][] = [];
       for (const userId of userIds) {
-        const count = await this.getConsecutiveGlueCount(userId);
+        const count = await this.getConsecutiveGlueCount(channelId, userId);
         if (count >= threshold) {
-          const history = await this.getUserHistory(userId, count);
+          const history = await this.getUserHistory(channelId, userId, count);
           atRisk.push(history);
         }
       }

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -8,6 +8,7 @@ import type { Mood } from "./bot.ts";
 
 /** A single vote record from a user */
 export interface VoteRecord {
+  channelId: string;
   odUserId: string;
   odUserName: string;
   mood: Mood;


### PR DESCRIPTION
## Summary
- require actual consecutive calendar days before counting a glue streak
- scope vote storage, stats, and wellness checks to each Discord channel
- add regression coverage for skipped days and cross-server contamination

## Testing
- deno test --unstable-kv src/services/storage.test.ts
- deno test --unstable-kv --allow-env