### PR TITLE
Add autonomous active conversation chat

### DIFF
--- a/ai_service.test.ts
+++ b/ai_service.test.ts
@@ -29,7 +29,7 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     autonomousChatEnabled: false,
     autonomousChatMinHumanMessages: 4,
     autonomousChatActivityWindowMinutes: 20,
-    autonomousChatCooldownMinutes: 30,
+    autonomousChatCooldownMinutes: 1,
     autonomousChatReplyChance: 0.35,
     autonomousChatMaxContextMessages: 40,
     ...overrides,

--- a/ai_service.test.ts
+++ b/ai_service.test.ts
@@ -26,6 +26,12 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webSearchApiKey: undefined,
     webSearchMaxResults: 3,
     linkOpenEnabled: true,
+    autonomousChatEnabled: false,
+    autonomousChatMinHumanMessages: 4,
+    autonomousChatActivityWindowMinutes: 20,
+    autonomousChatCooldownMinutes: 30,
+    autonomousChatReplyChance: 0.35,
+    autonomousChatMaxContextMessages: 40,
     ...overrides,
   };
 }

--- a/ai_service.test.ts
+++ b/ai_service.test.ts
@@ -27,6 +27,7 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webSearchMaxResults: 3,
     linkOpenEnabled: true,
     autonomousChatEnabled: false,
+    autonomousChatChannelIds: ["test-channel"],
     autonomousChatMinHumanMessages: 4,
     autonomousChatActivityWindowMinutes: 20,
     autonomousChatCooldownMinutes: 1,

--- a/ai_service.ts
+++ b/ai_service.ts
@@ -309,6 +309,12 @@ export async function generateReplyFromMessages(
     webSearchApiKey: web_search_api_key,
     webSearchMaxResults: parseInt(Deno.env.get("WEB_SEARCH_MAX_RESULTS") ?? "3", 10),
     linkOpenEnabled: link_open_enabled,
+    autonomousChatEnabled: false,
+    autonomousChatMinHumanMessages: 4,
+    autonomousChatActivityWindowMinutes: 20,
+    autonomousChatCooldownMinutes: 30,
+    autonomousChatReplyChance: 0.35,
+    autonomousChatMaxContextMessages: 40,
   };
 
   const service = createAiService(legacy_config);

--- a/ai_service.ts
+++ b/ai_service.ts
@@ -312,7 +312,7 @@ export async function generateReplyFromMessages(
     autonomousChatEnabled: false,
     autonomousChatMinHumanMessages: 4,
     autonomousChatActivityWindowMinutes: 20,
-    autonomousChatCooldownMinutes: 30,
+    autonomousChatCooldownMinutes: 1,
     autonomousChatReplyChance: 0.35,
     autonomousChatMaxContextMessages: 40,
   };

--- a/ai_service.ts
+++ b/ai_service.ts
@@ -310,6 +310,7 @@ export async function generateReplyFromMessages(
     webSearchMaxResults: parseInt(Deno.env.get("WEB_SEARCH_MAX_RESULTS") ?? "3", 10),
     linkOpenEnabled: link_open_enabled,
     autonomousChatEnabled: false,
+    autonomousChatChannelIds: channel_ids.length > 0 ? channel_ids : [channel_id_single],
     autonomousChatMinHumanMessages: 4,
     autonomousChatActivityWindowMinutes: 20,
     autonomousChatCooldownMinutes: 1,

--- a/bot_actions.get_bot_user_id.test.ts
+++ b/bot_actions.get_bot_user_id.test.ts
@@ -19,6 +19,12 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webSearchApiKey: "brave-key",
     webSearchMaxResults: 3,
     linkOpenEnabled: true,
+    autonomousChatEnabled: false,
+    autonomousChatMinHumanMessages: 4,
+    autonomousChatActivityWindowMinutes: 20,
+    autonomousChatCooldownMinutes: 30,
+    autonomousChatReplyChance: 0.35,
+    autonomousChatMaxContextMessages: 40,
     ...overrides,
   };
 }

--- a/bot_actions.get_bot_user_id.test.ts
+++ b/bot_actions.get_bot_user_id.test.ts
@@ -22,7 +22,7 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     autonomousChatEnabled: false,
     autonomousChatMinHumanMessages: 4,
     autonomousChatActivityWindowMinutes: 20,
-    autonomousChatCooldownMinutes: 30,
+    autonomousChatCooldownMinutes: 1,
     autonomousChatReplyChance: 0.35,
     autonomousChatMaxContextMessages: 40,
     ...overrides,

--- a/bot_actions.get_bot_user_id.test.ts
+++ b/bot_actions.get_bot_user_id.test.ts
@@ -20,6 +20,7 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webSearchMaxResults: 3,
     linkOpenEnabled: true,
     autonomousChatEnabled: false,
+    autonomousChatChannelIds: ["chan-1"],
     autonomousChatMinHumanMessages: 4,
     autonomousChatActivityWindowMinutes: 20,
     autonomousChatCooldownMinutes: 1,

--- a/bot_actions.handle_guards.test.ts
+++ b/bot_actions.handle_guards.test.ts
@@ -21,6 +21,12 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webSearchApiKey: "brave-key",
     webSearchMaxResults: 3,
     linkOpenEnabled: true,
+    autonomousChatEnabled: false,
+    autonomousChatMinHumanMessages: 4,
+    autonomousChatActivityWindowMinutes: 20,
+    autonomousChatCooldownMinutes: 30,
+    autonomousChatReplyChance: 0.35,
+    autonomousChatMaxContextMessages: 40,
     ...overrides,
   };
 }

--- a/bot_actions.handle_guards.test.ts
+++ b/bot_actions.handle_guards.test.ts
@@ -22,6 +22,7 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webSearchMaxResults: 3,
     linkOpenEnabled: true,
     autonomousChatEnabled: false,
+    autonomousChatChannelIds: ["chan-1"],
     autonomousChatMinHumanMessages: 4,
     autonomousChatActivityWindowMinutes: 20,
     autonomousChatCooldownMinutes: 1,

--- a/bot_actions.handle_guards.test.ts
+++ b/bot_actions.handle_guards.test.ts
@@ -24,7 +24,7 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     autonomousChatEnabled: false,
     autonomousChatMinHumanMessages: 4,
     autonomousChatActivityWindowMinutes: 20,
-    autonomousChatCooldownMinutes: 30,
+    autonomousChatCooldownMinutes: 1,
     autonomousChatReplyChance: 0.35,
     autonomousChatMaxContextMessages: 40,
     ...overrides,

--- a/bot_actions.test.ts
+++ b/bot_actions.test.ts
@@ -36,7 +36,7 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     autonomousChatEnabled: false,
     autonomousChatMinHumanMessages: 4,
     autonomousChatActivityWindowMinutes: 20,
-    autonomousChatCooldownMinutes: 30,
+    autonomousChatCooldownMinutes: 1,
     autonomousChatReplyChance: 0.35,
     autonomousChatMaxContextMessages: 40,
     ...overrides,

--- a/bot_actions.test.ts
+++ b/bot_actions.test.ts
@@ -34,6 +34,7 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webSearchMaxResults: 3,
     linkOpenEnabled: true,
     autonomousChatEnabled: false,
+    autonomousChatChannelIds: ["chan-1"],
     autonomousChatMinHumanMessages: 4,
     autonomousChatActivityWindowMinutes: 20,
     autonomousChatCooldownMinutes: 1,

--- a/bot_actions.test.ts
+++ b/bot_actions.test.ts
@@ -33,6 +33,12 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webSearchApiKey: "brave-key",
     webSearchMaxResults: 3,
     linkOpenEnabled: true,
+    autonomousChatEnabled: false,
+    autonomousChatMinHumanMessages: 4,
+    autonomousChatActivityWindowMinutes: 20,
+    autonomousChatCooldownMinutes: 30,
+    autonomousChatReplyChance: 0.35,
+    autonomousChatMaxContextMessages: 40,
     ...overrides,
   };
 }

--- a/main.ts
+++ b/main.ts
@@ -46,7 +46,7 @@ const date_formatter = new Intl.DateTimeFormat("en-US", {
 
 // --- Register Services ---
 startGateway(config, bot_deps);
-registerCronJobs(config, discord, storage, date_formatter);
+registerCronJobs(config, discord, storage, date_formatter, ai_service, rate_limit);
 createServer(config, discord, storage, date_formatter, rate_limit);
 
 // --- Startup Logging ---
@@ -76,3 +76,11 @@ if (!config.webSearchApiKey) {
 console.log("");
 console.log("🔗 Link Open:");
 console.log(`   Enabled: ${config.linkOpenEnabled}`);
+console.log("");
+console.log("💬 Autonomous Chat:");
+console.log(`   Enabled: ${config.autonomousChatEnabled}`);
+console.log(`   Min Human Messages: ${config.autonomousChatMinHumanMessages}`);
+console.log(`   Activity Window: ${config.autonomousChatActivityWindowMinutes} minutes`);
+console.log(`   Cooldown: ${config.autonomousChatCooldownMinutes} minutes`);
+console.log(`   Reply Chance: ${config.autonomousChatReplyChance}`);
+console.log(`   Max Context Messages: ${config.autonomousChatMaxContextMessages}`);

--- a/main.ts
+++ b/main.ts
@@ -79,6 +79,7 @@ console.log(`   Enabled: ${config.linkOpenEnabled}`);
 console.log("");
 console.log("💬 Autonomous Chat:");
 console.log(`   Enabled: ${config.autonomousChatEnabled}`);
+console.log(`   Channels: ${config.autonomousChatChannelIds.join(", ")}`);
 console.log(`   Min Human Messages: ${config.autonomousChatMinHumanMessages}`);
 console.log(`   Activity Window: ${config.autonomousChatActivityWindowMinutes} minutes`);
 console.log(`   Cooldown: ${config.autonomousChatCooldownMinutes} minutes`);

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -30,6 +30,7 @@ function withEnv(
     "WEB_SEARCH_MAX_RESULTS",
     "LINK_OPEN_ENABLED",
     "AUTONOMOUS_CHAT_ENABLED",
+    "AUTONOMOUS_CHAT_CHANNEL_IDS",
     "AUTONOMOUS_CHAT_MIN_HUMAN_MESSAGES",
     "AUTONOMOUS_CHAT_ACTIVITY_WINDOW_MINUTES",
     "AUTONOMOUS_CHAT_COOLDOWN_MINUTES",
@@ -206,6 +207,7 @@ Deno.test("loadConfig returns complete config with all values", () => {
       WEB_SEARCH_MAX_RESULTS: "5",
       LINK_OPEN_ENABLED: "false",
       AUTONOMOUS_CHAT_ENABLED: "true",
+      AUTONOMOUS_CHAT_CHANNEL_IDS: "auto-1, auto-2",
       AUTONOMOUS_CHAT_MIN_HUMAN_MESSAGES: "6",
       AUTONOMOUS_CHAT_ACTIVITY_WINDOW_MINUTES: "25",
       AUTONOMOUS_CHAT_COOLDOWN_MINUTES: "45",
@@ -231,6 +233,7 @@ Deno.test("loadConfig returns complete config with all values", () => {
         webSearchMaxResults: 5,
         linkOpenEnabled: false,
         autonomousChatEnabled: true,
+        autonomousChatChannelIds: ["auto-1", "auto-2"],
         autonomousChatMinHumanMessages: 6,
         autonomousChatActivityWindowMinutes: 25,
         autonomousChatCooldownMinutes: 45,
@@ -261,11 +264,40 @@ Deno.test("loadConfig uses AI defaults when not set", () => {
       assertEquals(config.webSearchMaxResults, 3);
       assertEquals(config.linkOpenEnabled, true);
       assertEquals(config.autonomousChatEnabled, false);
+      assertEquals(config.autonomousChatChannelIds, ["channel"]);
       assertEquals(config.autonomousChatMinHumanMessages, 4);
       assertEquals(config.autonomousChatActivityWindowMinutes, 20);
       assertEquals(config.autonomousChatCooldownMinutes, 1);
       assertEquals(config.autonomousChatReplyChance, 0.35);
       assertEquals(config.autonomousChatMaxContextMessages, 40);
+    },
+  );
+});
+
+Deno.test("loadConfig defaults AUTONOMOUS_CHAT_CHANNEL_IDS to configured channels", () => {
+  withEnv(
+    {
+      DISCORD_TOKEN: "token",
+      CHANNEL_IDS: "chan-1, chan-2",
+    },
+    () => {
+      const config = loadConfig();
+      assertEquals(config.autonomousChatChannelIds, ["chan-1", "chan-2"]);
+    },
+  );
+});
+
+Deno.test("loadConfig supports AUTONOMOUS_CHAT_CHANNEL_IDS override", () => {
+  withEnv(
+    {
+      DISCORD_TOKEN: "token",
+      CHANNEL_IDS: "chan-1, chan-2",
+      AUTONOMOUS_CHAT_CHANNEL_IDS: "auto-1, auto-2, auto-1",
+    },
+    () => {
+      const config = loadConfig();
+      assertEquals(config.channelIds, ["chan-1", "chan-2"]);
+      assertEquals(config.autonomousChatChannelIds, ["auto-1", "auto-2"]);
     },
   );
 });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -29,6 +29,12 @@ function withEnv(
     "BRAVE_SEARCH_API_KEY",
     "WEB_SEARCH_MAX_RESULTS",
     "LINK_OPEN_ENABLED",
+    "AUTONOMOUS_CHAT_ENABLED",
+    "AUTONOMOUS_CHAT_MIN_HUMAN_MESSAGES",
+    "AUTONOMOUS_CHAT_ACTIVITY_WINDOW_MINUTES",
+    "AUTONOMOUS_CHAT_COOLDOWN_MINUTES",
+    "AUTONOMOUS_CHAT_REPLY_CHANCE",
+    "AUTONOMOUS_CHAT_MAX_CONTEXT_MESSAGES",
   ]);
 
   for (const key of allKeys) {
@@ -199,6 +205,12 @@ Deno.test("loadConfig returns complete config with all values", () => {
       BRAVE_SEARCH_API_KEY: "brave-key",
       WEB_SEARCH_MAX_RESULTS: "5",
       LINK_OPEN_ENABLED: "false",
+      AUTONOMOUS_CHAT_ENABLED: "true",
+      AUTONOMOUS_CHAT_MIN_HUMAN_MESSAGES: "6",
+      AUTONOMOUS_CHAT_ACTIVITY_WINDOW_MINUTES: "25",
+      AUTONOMOUS_CHAT_COOLDOWN_MINUTES: "45",
+      AUTONOMOUS_CHAT_REPLY_CHANCE: "0.2",
+      AUTONOMOUS_CHAT_MAX_CONTEXT_MESSAGES: "60",
     },
     () => {
       const config = loadConfig();
@@ -218,6 +230,12 @@ Deno.test("loadConfig returns complete config with all values", () => {
         webSearchApiKey: "brave-key",
         webSearchMaxResults: 5,
         linkOpenEnabled: false,
+        autonomousChatEnabled: true,
+        autonomousChatMinHumanMessages: 6,
+        autonomousChatActivityWindowMinutes: 25,
+        autonomousChatCooldownMinutes: 45,
+        autonomousChatReplyChance: 0.2,
+        autonomousChatMaxContextMessages: 60,
       });
     },
   );
@@ -242,6 +260,12 @@ Deno.test("loadConfig uses AI defaults when not set", () => {
       assertEquals(config.webSearchApiKey, undefined);
       assertEquals(config.webSearchMaxResults, 3);
       assertEquals(config.linkOpenEnabled, true);
+      assertEquals(config.autonomousChatEnabled, false);
+      assertEquals(config.autonomousChatMinHumanMessages, 4);
+      assertEquals(config.autonomousChatActivityWindowMinutes, 20);
+      assertEquals(config.autonomousChatCooldownMinutes, 30);
+      assertEquals(config.autonomousChatReplyChance, 0.35);
+      assertEquals(config.autonomousChatMaxContextMessages, 40);
     },
   );
 });
@@ -300,6 +324,34 @@ Deno.test("loadConfig handles LINK_OPEN_ENABLED=false", () => {
     () => {
       const config = loadConfig();
       assertEquals(config.linkOpenEnabled, false);
+    },
+  );
+});
+
+Deno.test("loadConfig clamps AUTONOMOUS_CHAT_REPLY_CHANCE", () => {
+  withEnv(
+    {
+      DISCORD_TOKEN: "token",
+      CHANNEL_ID: "channel",
+      AUTONOMOUS_CHAT_REPLY_CHANCE: "2",
+    },
+    () => {
+      const config = loadConfig();
+      assertEquals(config.autonomousChatReplyChance, 1);
+    },
+  );
+});
+
+Deno.test("loadConfig defaults invalid AUTONOMOUS_CHAT_REPLY_CHANCE", () => {
+  withEnv(
+    {
+      DISCORD_TOKEN: "token",
+      CHANNEL_ID: "channel",
+      AUTONOMOUS_CHAT_REPLY_CHANCE: "sometimes",
+    },
+    () => {
+      const config = loadConfig();
+      assertEquals(config.autonomousChatReplyChance, 0.35);
     },
   );
 });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -263,7 +263,7 @@ Deno.test("loadConfig uses AI defaults when not set", () => {
       assertEquals(config.autonomousChatEnabled, false);
       assertEquals(config.autonomousChatMinHumanMessages, 4);
       assertEquals(config.autonomousChatActivityWindowMinutes, 20);
-      assertEquals(config.autonomousChatCooldownMinutes, 30);
+      assertEquals(config.autonomousChatCooldownMinutes, 1);
       assertEquals(config.autonomousChatReplyChance, 0.35);
       assertEquals(config.autonomousChatMaxContextMessages, 40);
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,20 @@ export interface AppConfig {
   // Link Open
   /** Master switch for explicit link opening command (default: true) */
   linkOpenEnabled: boolean;
+
+  // Autonomous Chat
+  /** Allow Haru to speak without a direct mention during active conversations (default: false) */
+  autonomousChatEnabled: boolean;
+  /** Minimum recent human messages before autonomous chat can join (default: 4) */
+  autonomousChatMinHumanMessages: number;
+  /** Minutes used to decide whether a channel is currently active (default: 20) */
+  autonomousChatActivityWindowMinutes: number;
+  /** Minutes Haru waits after speaking before speaking again (default: 30) */
+  autonomousChatCooldownMinutes: number;
+  /** Probability [0, 1] of replying when the channel is eligible (default: 0.35) */
+  autonomousChatReplyChance: number;
+  /** Max recent messages sent to the AI for autonomous replies (default: 40) */
+  autonomousChatMaxContextMessages: number;
 }
 
 /**
@@ -67,6 +81,12 @@ export function loadConfig(): AppConfig {
     (web_search_api_key ? "true" : "false")).toLowerCase() !== "false";
   const link_open_enabled = (Deno.env.get("LINK_OPEN_ENABLED") ?? "true").toLowerCase() !==
     "false";
+  const parsed_autonomous_chat_reply_chance = parseFloat(
+    Deno.env.get("AUTONOMOUS_CHAT_REPLY_CHANCE") ?? "0.35",
+  );
+  const autonomous_chat_reply_chance = Number.isFinite(parsed_autonomous_chat_reply_chance)
+    ? parsed_autonomous_chat_reply_chance
+    : 0.35;
   const channel_ids_raw = Deno.env.get("CHANNEL_IDS");
   const channel_id_single = Deno.env.get("CHANNEL_ID");
 
@@ -109,5 +129,26 @@ export function loadConfig(): AppConfig {
 
     // Link Open
     linkOpenEnabled: link_open_enabled,
+
+    // Autonomous Chat
+    autonomousChatEnabled: (Deno.env.get("AUTONOMOUS_CHAT_ENABLED") ?? "false").toLowerCase() ===
+      "true",
+    autonomousChatMinHumanMessages: parseInt(
+      Deno.env.get("AUTONOMOUS_CHAT_MIN_HUMAN_MESSAGES") ?? "4",
+      10,
+    ),
+    autonomousChatActivityWindowMinutes: parseInt(
+      Deno.env.get("AUTONOMOUS_CHAT_ACTIVITY_WINDOW_MINUTES") ?? "20",
+      10,
+    ),
+    autonomousChatCooldownMinutes: parseInt(
+      Deno.env.get("AUTONOMOUS_CHAT_COOLDOWN_MINUTES") ?? "30",
+      10,
+    ),
+    autonomousChatReplyChance: Math.min(1, Math.max(0, autonomous_chat_reply_chance)),
+    autonomousChatMaxContextMessages: parseInt(
+      Deno.env.get("AUTONOMOUS_CHAT_MAX_CONTEXT_MESSAGES") ?? "40",
+      10,
+    ),
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,8 @@ export interface AppConfig {
   // Autonomous Chat
   /** Allow Haru to speak without a direct mention during active conversations (default: false) */
   autonomousChatEnabled: boolean;
+  /** Channels where autonomous chat is allowed (default: all configured channels) */
+  autonomousChatChannelIds: string[];
   /** Minimum recent human messages before autonomous chat can join (default: 4) */
   autonomousChatMinHumanMessages: number;
   /** Minutes used to decide whether a channel is currently active (default: 20) */
@@ -106,6 +108,10 @@ export function loadConfig(): AppConfig {
   }
 
   const channel_ids_unique = [...new Set(channel_ids)];
+  const autonomous_chat_channel_ids_raw = Deno.env.get("AUTONOMOUS_CHAT_CHANNEL_IDS");
+  const autonomous_chat_channel_ids = autonomous_chat_channel_ids_raw
+    ? autonomous_chat_channel_ids_raw.split(",").map((id) => id.trim()).filter(Boolean)
+    : channel_ids_unique;
 
   return {
     discordToken: getEnvOrThrow("DISCORD_TOKEN"),
@@ -133,6 +139,7 @@ export function loadConfig(): AppConfig {
     // Autonomous Chat
     autonomousChatEnabled: (Deno.env.get("AUTONOMOUS_CHAT_ENABLED") ?? "false").toLowerCase() ===
       "true",
+    autonomousChatChannelIds: [...new Set(autonomous_chat_channel_ids)],
     autonomousChatMinHumanMessages: parseInt(
       Deno.env.get("AUTONOMOUS_CHAT_MIN_HUMAN_MESSAGES") ?? "4",
       10,

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,7 +48,7 @@ export interface AppConfig {
   autonomousChatMinHumanMessages: number;
   /** Minutes used to decide whether a channel is currently active (default: 20) */
   autonomousChatActivityWindowMinutes: number;
-  /** Minutes Haru waits after speaking before speaking again (default: 30) */
+  /** Minutes Haru waits after speaking before speaking again (default: 1) */
   autonomousChatCooldownMinutes: number;
   /** Probability [0, 1] of replying when the channel is eligible (default: 0.35) */
   autonomousChatReplyChance: number;
@@ -142,7 +142,7 @@ export function loadConfig(): AppConfig {
       10,
     ),
     autonomousChatCooldownMinutes: parseInt(
-      Deno.env.get("AUTONOMOUS_CHAT_COOLDOWN_MINUTES") ?? "30",
+      Deno.env.get("AUTONOMOUS_CHAT_COOLDOWN_MINUTES") ?? "1",
       10,
     ),
     autonomousChatReplyChance: Math.min(1, Math.max(0, autonomous_chat_reply_chance)),

--- a/src/features/autonomous_chat/autonomous_chat.test.ts
+++ b/src/features/autonomous_chat/autonomous_chat.test.ts
@@ -1,0 +1,118 @@
+import { assertEquals } from "@std/assert";
+import { decideAutonomousChatReply, type RecentDiscordMessage } from "./mod.ts";
+
+const NOW_MS = Date.parse("2026-06-11T20:00:00.000Z");
+
+function isoMinutesAgo(minutes: number): string {
+  return new Date(NOW_MS - minutes * 60_000).toISOString();
+}
+
+function message(
+  id: string,
+  authorId: string,
+  minutesAgo: number,
+  content = "hello",
+  overrides: Partial<RecentDiscordMessage> = {},
+): RecentDiscordMessage {
+  return {
+    id,
+    authorId,
+    authorName: `user-${authorId}`,
+    authorBot: false,
+    content,
+    timestamp: isoMinutesAgo(minutesAgo),
+    imageUrls: [],
+    ...overrides,
+  };
+}
+
+function decide(
+  messages: RecentDiscordMessage[],
+  overrides: Partial<Parameters<typeof decideAutonomousChatReply>[1]> = {},
+) {
+  return decideAutonomousChatReply(messages, {
+    botUserId: "haru",
+    nowMs: NOW_MS,
+    minHumanMessages: 4,
+    activityWindowMs: 20 * 60_000,
+    cooldownMs: 30 * 60_000,
+    maxContextMessages: 40,
+    replyChance: 1,
+    random: () => 0,
+    ...overrides,
+  });
+}
+
+Deno.test("decideAutonomousChatReply skips when there is not enough recent human activity", () => {
+  const decision = decide([
+    message("m1", "u1", 4),
+    message("m2", "u2", 3),
+    message("m3", "u3", 2),
+  ]);
+
+  assertEquals(decision.shouldReply, false);
+  assertEquals(decision.reason, "only 3 recent human message(s)");
+});
+
+Deno.test("decideAutonomousChatReply skips while Haru cooldown is active", () => {
+  const decision = decide([
+    message("m1", "u1", 10),
+    message("m2", "u2", 9),
+    message("m3", "haru", 8, "same", { authorBot: true }),
+    message("m4", "u3", 7),
+    message("m5", "u4", 6),
+    message("m6", "u5", 5),
+    message("m7", "u6", 4),
+  ]);
+
+  assertEquals(decision.shouldReply, false);
+  assertEquals(decision.reason, "cooldown active");
+});
+
+Deno.test("decideAutonomousChatReply skips when nobody spoke after Haru", () => {
+  const decision = decide(
+    [
+      message("m1", "u1", 55),
+      message("m2", "u2", 54),
+      message("m3", "u3", 53),
+      message("m4", "u4", 52),
+      message("m5", "haru", 50, "bye", { authorBot: true }),
+    ],
+    { activityWindowMs: 120 * 60_000 },
+  );
+
+  assertEquals(decision.shouldReply, false);
+  assertEquals(decision.reason, "no human message after Haru");
+});
+
+Deno.test("decideAutonomousChatReply skips when the random gate misses", () => {
+  const decision = decide(
+    [
+      message("m1", "u1", 4),
+      message("m2", "u2", 3),
+      message("m3", "u3", 2),
+      message("m4", "u4", 1),
+    ],
+    { replyChance: 0.25, random: () => 0.9 },
+  );
+
+  assertEquals(decision.shouldReply, false);
+  assertEquals(decision.reason, "random gate skipped");
+});
+
+Deno.test("decideAutonomousChatReply returns capped oldest-to-newest context when eligible", () => {
+  const decision = decide(
+    [
+      message("m1", "u1", 5, "one"),
+      message("m2", "u2", 4, "two"),
+      message("m3", "u3", 3, "three"),
+      message("m4", "u4", 2, "four"),
+      message("m5", "u5", 1, "five"),
+    ],
+    { maxContextMessages: 3 },
+  );
+
+  assertEquals(decision.shouldReply, true);
+  assertEquals(decision.reason, "active conversation eligible");
+  assertEquals(decision.contextMessages.map((context) => context.id), ["m3", "m4", "m5"]);
+});

--- a/src/features/autonomous_chat/mod.ts
+++ b/src/features/autonomous_chat/mod.ts
@@ -1,0 +1,133 @@
+export interface RecentDiscordMessage {
+  id: string;
+  authorId: string;
+  authorName: string;
+  authorBot: boolean;
+  content: string;
+  timestamp: string;
+  imageUrls: string[];
+}
+
+export interface AutonomousChatOptions {
+  botUserId: string;
+  nowMs: number;
+  minHumanMessages: number;
+  activityWindowMs: number;
+  cooldownMs: number;
+  maxContextMessages: number;
+  replyChance: number;
+  random: () => number;
+}
+
+export interface AutonomousChatDecision {
+  shouldReply: boolean;
+  reason: string;
+  contextMessages: Array<Record<string, unknown>>;
+}
+
+interface TimestampedRecentMessage {
+  message: RecentDiscordMessage;
+  timestampMs: number;
+  index: number;
+}
+
+function nTimestampMs(timestamp: string): number | null {
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function bHasConversationContent(message: RecentDiscordMessage): boolean {
+  return message.content.trim().length > 0 || message.imageUrls.length > 0;
+}
+
+function bIsHumanMessage(message: RecentDiscordMessage, botUserId: string): boolean {
+  return !message.authorBot && message.authorId !== botUserId;
+}
+
+function oToAiContextMessage(message: RecentDiscordMessage): Record<string, unknown> {
+  return {
+    id: message.id,
+    author: message.authorName || message.authorId || "unknown",
+    content: message.content,
+    imageUrls: message.imageUrls,
+    timestamp: message.timestamp,
+  };
+}
+
+export function decideAutonomousChatReply(
+  messages: RecentDiscordMessage[],
+  options: AutonomousChatOptions,
+): AutonomousChatDecision {
+  const timestamped: TimestampedRecentMessage[] = messages
+    .map((message, index) => {
+      const timestamp_ms = nTimestampMs(message.timestamp);
+      if (timestamp_ms === null) return null;
+      return { message, timestampMs: timestamp_ms, index };
+    })
+    .filter((item): item is TimestampedRecentMessage => item !== null)
+    .filter(({ message }) => bHasConversationContent(message))
+    .sort((a, b) => a.timestampMs - b.timestampMs || a.index - b.index);
+
+  if (timestamped.length === 0) {
+    return { shouldReply: false, reason: "no valid recent messages", contextMessages: [] };
+  }
+
+  const min_human_messages = Math.max(1, options.minHumanMessages);
+  const recent_human_messages = timestamped.filter(({ message, timestampMs }) => {
+    const age_ms = options.nowMs - timestampMs;
+    return age_ms >= 0 &&
+      age_ms <= options.activityWindowMs &&
+      bIsHumanMessage(message, options.botUserId);
+  });
+
+  if (recent_human_messages.length < min_human_messages) {
+    return {
+      shouldReply: false,
+      reason: `only ${recent_human_messages.length} recent human message(s)`,
+      contextMessages: [],
+    };
+  }
+
+  const last_haru_message = [...timestamped]
+    .reverse()
+    .find(({ message }) => message.authorId === options.botUserId);
+
+  if (last_haru_message) {
+    const elapsed_ms = options.nowMs - last_haru_message.timestampMs;
+    if (elapsed_ms >= 0 && elapsed_ms < options.cooldownMs) {
+      return { shouldReply: false, reason: "cooldown active", contextMessages: [] };
+    }
+
+    const has_human_after_haru = timestamped.some(({ message, timestampMs }) =>
+      timestampMs > last_haru_message.timestampMs &&
+      bIsHumanMessage(message, options.botUserId)
+    );
+
+    if (!has_human_after_haru) {
+      return {
+        shouldReply: false,
+        reason: "no human message after Haru",
+        contextMessages: [],
+      };
+    }
+  }
+
+  if (options.replyChance <= 0) {
+    return { shouldReply: false, reason: "reply chance disabled", contextMessages: [] };
+  }
+
+  if (options.random() > options.replyChance) {
+    return { shouldReply: false, reason: "random gate skipped", contextMessages: [] };
+  }
+
+  const context_limit = Math.max(1, options.maxContextMessages);
+  const context_messages = timestamped
+    .slice(-context_limit)
+    .map(({ message }) => oToAiContextMessage(message));
+
+  return {
+    shouldReply: true,
+    reason: "active conversation eligible",
+    contextMessages: context_messages,
+  };
+}

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -8,13 +8,20 @@
  */
 
 import type { AppConfig } from "./config.ts";
+import type { AiService } from "../ai_service.ts";
 import type { DiscordClient } from "./services/discord.ts";
+import type { RateLimitService } from "./services/rate_limit.ts";
 import type { StorageService } from "./services/storage.ts";
 import type { PollRecord } from "./types/storage.ts";
 import type { Mood } from "./types/bot.ts";
+import { getBotUserId } from "../bot_actions.ts";
+import { decideAutonomousChatReply } from "./features/autonomous_chat/mod.ts";
 import { buildMoodPollPayload } from "./features/poll/mod.ts";
 import { buildAlertEmbed, buildStatsEmbed } from "./features/stats/mod.ts";
 import { DEFAULT_MOOD_CONFIG } from "./types/bot.ts";
+
+const AUTONOMOUS_CHAT_GUIDANCE =
+  "Autonomous reply guidance: You are Haru joining an already-active group chat without being directly mentioned. Send one brief, natural message that responds to the latest context. Do not say this is automated, scheduled, or from a cron job. Do not force a reply if the context is sensitive; be supportive and concise. Keep it under 280 characters.";
 
 /**
  * Registers all cron jobs for the application.
@@ -23,13 +30,19 @@ import { DEFAULT_MOOD_CONFIG } from "./types/bot.ts";
  * @param discord - Discord API client
  * @param storage - Storage service for vote data
  * @param dateFormatter - Date formatter for poll questions
+ * @param aiService - AI service for autonomous chat replies
+ * @param rateLimit - Rate limit service for AI budget tracking
  */
 export function registerCronJobs(
   config: AppConfig,
   discord: DiscordClient,
   storage: StorageService,
   dateFormatter: Intl.DateTimeFormat,
+  aiService: AiService,
+  rateLimit: RateLimitService,
 ): void {
+  let autonomous_chat_running = false;
+
   // =========================================================================
   // Daily Mood Poll
   // Schedule: 05:00 UTC = 21:00 PST / 22:00 PDT
@@ -208,9 +221,90 @@ export function registerCronJobs(
     }
   });
 
+  // =========================================================================
+  // Autonomous Chat
+  // Schedule: Every 10 minutes
+  // Joins active conversations only when explicitly enabled and guardrails pass.
+  // =========================================================================
+  Deno.cron("Autonomous Chat", "*/10 * * * *", async () => {
+    if (!config.autonomousChatEnabled) return;
+    if (!config.aiEnabled || !config.openaiApiKey) {
+      console.log("[CRON] Autonomous chat skipped because AI is disabled or unconfigured");
+      return;
+    }
+    if (autonomous_chat_running) {
+      console.log("[CRON] Autonomous chat skipped because previous run is still active");
+      return;
+    }
+
+    autonomous_chat_running = true;
+    try {
+      const bot_user_id = await getBotUserId(config);
+      if (!bot_user_id) {
+        console.error("[CRON] Autonomous chat skipped because bot user id is unavailable");
+        return;
+      }
+
+      for (const channelId of config.channelIds) {
+        const recent_messages = await discord.getRecentMessages(
+          channelId,
+          config.autonomousChatMaxContextMessages,
+        );
+        const decision = decideAutonomousChatReply(recent_messages, {
+          botUserId: bot_user_id,
+          nowMs: Date.now(),
+          minHumanMessages: config.autonomousChatMinHumanMessages,
+          activityWindowMs: config.autonomousChatActivityWindowMinutes * 60_000,
+          cooldownMs: config.autonomousChatCooldownMinutes * 60_000,
+          maxContextMessages: config.autonomousChatMaxContextMessages,
+          replyChance: config.autonomousChatReplyChance,
+          random: Math.random,
+        });
+
+        if (!decision.shouldReply) {
+          console.log(`[CRON] Autonomous chat skipped in ${channelId}: ${decision.reason}`);
+          continue;
+        }
+
+        const budget_result = await rateLimit.checkDailyBudget();
+        if (!budget_result.allowed) {
+          console.log("[CRON] Autonomous chat skipped because daily token budget is exhausted");
+          continue;
+        }
+
+        await rateLimit.recordUserRequest("autonomous-chat");
+        const ai_result = await aiService.generateReply([
+          ...decision.contextMessages,
+          { author: "system", content: AUTONOMOUS_CHAT_GUIDANCE },
+        ]);
+
+        if (!ai_result.ok) {
+          console.error(`[CRON] Autonomous chat AI failed in ${channelId}: ${ai_result.error}`);
+          continue;
+        }
+
+        await rateLimit.recordTokenUsage(ai_result.tokensUsed);
+        const response = await discord.postMessage(channelId, { content: ai_result.text });
+
+        if (response.ok) {
+          console.log(`[CRON] Autonomous chat posted in ${channelId}`);
+        } else {
+          const body = await response.text();
+          console.error(`[CRON] Autonomous chat failed in ${channelId}: ${response.status}`);
+          console.error(body);
+        }
+      }
+    } catch (error) {
+      console.error("[CRON] Error in autonomous chat:", error);
+    } finally {
+      autonomous_chat_running = false;
+    }
+  });
+
   console.log("[CRON] Registered jobs:");
   console.log("  - Daily Retro Poll (05:00 UTC)");
   console.log("  - Daily Wellness Check (06:00 UTC)");
   console.log("  - Weekly Stats Summary (Sundays 06:00 UTC)");
   console.log("  - Poll Result Collection (every hour at :30)");
+  console.log("  - Autonomous Chat (every 10 minutes, disabled unless configured)");
 }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -223,10 +223,10 @@ export function registerCronJobs(
 
   // =========================================================================
   // Autonomous Chat
-  // Schedule: Every 10 minutes
+  // Schedule: Every minute
   // Joins active conversations only when explicitly enabled and guardrails pass.
   // =========================================================================
-  Deno.cron("Autonomous Chat", "*/10 * * * *", async () => {
+  Deno.cron("Autonomous Chat", "* * * * *", async () => {
     if (!config.autonomousChatEnabled) return;
     if (!config.aiEnabled || !config.openaiApiKey) {
       console.log("[CRON] Autonomous chat skipped because AI is disabled or unconfigured");
@@ -306,5 +306,5 @@ export function registerCronJobs(
   console.log("  - Daily Wellness Check (06:00 UTC)");
   console.log("  - Weekly Stats Summary (Sundays 06:00 UTC)");
   console.log("  - Poll Result Collection (every hour at :30)");
-  console.log("  - Autonomous Chat (every 10 minutes, disabled unless configured)");
+  console.log("  - Autonomous Chat (every minute, disabled unless configured)");
 }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -245,7 +245,7 @@ export function registerCronJobs(
         return;
       }
 
-      for (const channelId of config.channelIds) {
+      for (const channelId of config.autonomousChatChannelIds) {
         const recent_messages = await discord.getRecentMessages(
           channelId,
           config.autonomousChatMaxContextMessages,

--- a/src/services/discord.test.ts
+++ b/src/services/discord.test.ts
@@ -1,0 +1,84 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { createDiscordClient } from "./discord.ts";
+
+function mockFetch(
+  handler: (url: string, init?: RequestInit) => Response | Promise<Response>,
+): { restore: () => void } {
+  const original_fetch = globalThis.fetch;
+
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    return Promise.resolve(handler(url, init));
+  }) as typeof fetch;
+
+  return {
+    restore: () => {
+      globalThis.fetch = original_fetch;
+    },
+  };
+}
+
+Deno.test("getRecentMessages clamps limit and maps Discord message payloads", async () => {
+  let requested_url = "";
+  const fetch_mock = mockFetch((url) => {
+    requested_url = url;
+    return new Response(
+      JSON.stringify([
+        {
+          id: "msg-1",
+          content: "hello",
+          timestamp: "2026-06-11T20:00:00.000Z",
+          author: {
+            id: "user-1",
+            username: "alice",
+            global_name: "Alice",
+            bot: false,
+          },
+          attachments: [
+            {
+              url: "https://cdn.example.com/a.png",
+              content_type: "image/png",
+            },
+            {
+              url: "https://cdn.example.com/not-image.txt",
+              content_type: "text/plain",
+            },
+          ],
+        },
+      ]),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+
+  try {
+    const discord = createDiscordClient("token");
+    const messages = await discord.getRecentMessages("channel-1", 500);
+
+    assertStringIncludes(requested_url, "/channels/channel-1/messages?limit=100");
+    assertEquals(messages, [
+      {
+        id: "msg-1",
+        authorId: "user-1",
+        authorName: "Alice",
+        authorBot: false,
+        content: "hello",
+        timestamp: "2026-06-11T20:00:00.000Z",
+        imageUrls: ["https://cdn.example.com/a.png"],
+      },
+    ]);
+  } finally {
+    fetch_mock.restore();
+  }
+});
+
+Deno.test("getRecentMessages returns an empty array for Discord errors", async () => {
+  const fetch_mock = mockFetch(() => new Response("nope", { status: 403 }));
+
+  try {
+    const discord = createDiscordClient("token");
+    const messages = await discord.getRecentMessages("channel-1", 20);
+    assertEquals(messages, []);
+  } finally {
+    fetch_mock.restore();
+  }
+});

--- a/src/services/discord.ts
+++ b/src/services/discord.ts
@@ -10,9 +10,11 @@
 
 import type { CreatePollMessagePayload } from "../types/discord.ts";
 import type { EmbedMessagePayload } from "../features/stats/mod.ts";
+import type { RecentDiscordMessage } from "../features/autonomous_chat/mod.ts";
 import { fetchWithRetry } from "../utils/retry.ts";
 
 const API_BASE = "https://discord.com/api/v10";
+const IMAGE_FILE_EXT_RE = /\.(?:png|jpe?g|gif|webp|bmp|svg|tiff?)$/i;
 
 /** Generic message payload (polls, embeds, text, etc.) */
 export type MessagePayload =
@@ -52,12 +54,101 @@ export interface DiscordClient {
   sendDM(userId: string, payload: MessagePayload): Promise<Response>;
 
   /**
+   * Gets recent channel messages for context-aware scheduled jobs
+   * @param channelId - The Discord channel ID
+   * @param limit - Number of messages to fetch, clamped to Discord's 1-100 range
+   * @returns Recent messages in Discord API order (newest first)
+   */
+  getRecentMessages(channelId: string, limit: number): Promise<RecentDiscordMessage[]>;
+
+  /**
    * Gets voters for all answers in a poll
    * @param channelId - The channel containing the poll
    * @param messageId - The message ID of the poll
    * @returns Array of answers with their voters
    */
   getPollVoters(channelId: string, messageId: string): Promise<PollAnswerVoters[]>;
+}
+
+function bIsHttpUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function bAttachmentLooksLikeImage(attachment: Record<string, unknown>): boolean {
+  const content_type = attachment["content_type"];
+  if (typeof content_type === "string" && content_type.startsWith("image/")) {
+    return true;
+  }
+
+  const filename = attachment["filename"];
+  if (typeof filename === "string" && IMAGE_FILE_EXT_RE.test(filename)) {
+    return true;
+  }
+
+  const width = attachment["width"];
+  const height = attachment["height"];
+  return typeof width === "number" && width > 0 && typeof height === "number" && height > 0;
+}
+
+function aszExtractImageUrlsFromDiscordMessage(message: Record<string, unknown>): string[] {
+  const attachments = message["attachments"];
+  if (!Array.isArray(attachments)) return [];
+
+  const image_urls: string[] = [];
+  for (const raw_attachment of attachments) {
+    if (!raw_attachment || typeof raw_attachment !== "object") continue;
+
+    const attachment = raw_attachment as Record<string, unknown>;
+    if (!bAttachmentLooksLikeImage(attachment)) continue;
+
+    const candidate = typeof attachment["url"] === "string"
+      ? attachment["url"]
+      : (typeof attachment["proxy_url"] === "string" ? attachment["proxy_url"] : undefined);
+    if (!candidate) continue;
+
+    const trimmed = candidate.trim();
+    if (!trimmed || !bIsHttpUrl(trimmed)) continue;
+    image_urls.push(trimmed);
+  }
+
+  return [...new Set(image_urls)];
+}
+
+function szDiscordAuthorName(author: Record<string, unknown>): string {
+  const global_name = author["global_name"];
+  if (typeof global_name === "string" && global_name.trim()) return global_name;
+
+  const username = author["username"];
+  if (typeof username === "string" && username.trim()) return username;
+
+  const id = author["id"];
+  return typeof id === "string" && id.trim() ? id : "unknown";
+}
+
+function oMapRecentMessage(message: Record<string, unknown>): RecentDiscordMessage {
+  const author = message["author"] && typeof message["author"] === "object"
+    ? message["author"] as Record<string, unknown>
+    : {};
+
+  const id = message["id"];
+  const author_id = author["id"];
+  const content = message["content"];
+  const timestamp = message["timestamp"];
+
+  return {
+    id: typeof id === "string" ? id : "",
+    authorId: typeof author_id === "string" ? author_id : "",
+    authorName: szDiscordAuthorName(author),
+    authorBot: author["bot"] === true,
+    content: typeof content === "string" ? content : "",
+    timestamp: typeof timestamp === "string" ? timestamp : "",
+    imageUrls: aszExtractImageUrlsFromDiscordMessage(message),
+  };
 }
 
 /**
@@ -105,6 +196,31 @@ export function createDiscordClient(token: string): DiscordClient {
         headers,
         body: JSON.stringify(payload),
       });
+    },
+
+    async getRecentMessages(channelId, limit) {
+      const safe_limit = Math.min(100, Math.max(1, Math.trunc(limit)));
+      const response = await fetchWithRetry(
+        `${API_BASE}/channels/${channelId}/messages?limit=${safe_limit}`,
+        { headers },
+      );
+
+      if (!response.ok) {
+        console.error(`[DISCORD] Failed to get recent messages: ${response.status}`);
+        return [];
+      }
+
+      const data = await response.json();
+      if (!Array.isArray(data)) {
+        console.error("[DISCORD] Recent messages response was not an array");
+        return [];
+      }
+
+      return data
+        .filter((message): message is Record<string, unknown> =>
+          message !== null && typeof message === "object"
+        )
+        .map(oMapRecentMessage);
     },
 
     async getPollVoters(channelId, messageId) {

--- a/src/services/link_open.test.ts
+++ b/src/services/link_open.test.ts
@@ -26,7 +26,7 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     autonomousChatEnabled: false,
     autonomousChatMinHumanMessages: 4,
     autonomousChatActivityWindowMinutes: 20,
-    autonomousChatCooldownMinutes: 30,
+    autonomousChatCooldownMinutes: 1,
     autonomousChatReplyChance: 0.35,
     autonomousChatMaxContextMessages: 40,
     ...overrides,

--- a/src/services/link_open.test.ts
+++ b/src/services/link_open.test.ts
@@ -24,6 +24,7 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webSearchMaxResults: 3,
     linkOpenEnabled: true,
     autonomousChatEnabled: false,
+    autonomousChatChannelIds: ["test-channel"],
     autonomousChatMinHumanMessages: 4,
     autonomousChatActivityWindowMinutes: 20,
     autonomousChatCooldownMinutes: 1,

--- a/src/services/link_open.test.ts
+++ b/src/services/link_open.test.ts
@@ -23,6 +23,12 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webSearchApiKey: undefined,
     webSearchMaxResults: 3,
     linkOpenEnabled: true,
+    autonomousChatEnabled: false,
+    autonomousChatMinHumanMessages: 4,
+    autonomousChatActivityWindowMinutes: 20,
+    autonomousChatCooldownMinutes: 30,
+    autonomousChatReplyChance: 0.35,
+    autonomousChatMaxContextMessages: 40,
     ...overrides,
   };
 }

--- a/src/services/rate_limit.test.ts
+++ b/src/services/rate_limit.test.ts
@@ -25,6 +25,7 @@ function createTestConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webSearchMaxResults: 3,
     linkOpenEnabled: true,
     autonomousChatEnabled: false,
+    autonomousChatChannelIds: ["test-channel"],
     autonomousChatMinHumanMessages: 4,
     autonomousChatActivityWindowMinutes: 20,
     autonomousChatCooldownMinutes: 1,

--- a/src/services/rate_limit.test.ts
+++ b/src/services/rate_limit.test.ts
@@ -27,7 +27,7 @@ function createTestConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     autonomousChatEnabled: false,
     autonomousChatMinHumanMessages: 4,
     autonomousChatActivityWindowMinutes: 20,
-    autonomousChatCooldownMinutes: 30,
+    autonomousChatCooldownMinutes: 1,
     autonomousChatReplyChance: 0.35,
     autonomousChatMaxContextMessages: 40,
     ...overrides,

--- a/src/services/rate_limit.test.ts
+++ b/src/services/rate_limit.test.ts
@@ -24,6 +24,12 @@ function createTestConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webSearchApiKey: undefined,
     webSearchMaxResults: 3,
     linkOpenEnabled: true,
+    autonomousChatEnabled: false,
+    autonomousChatMinHumanMessages: 4,
+    autonomousChatActivityWindowMinutes: 20,
+    autonomousChatCooldownMinutes: 30,
+    autonomousChatReplyChance: 0.35,
+    autonomousChatMaxContextMessages: 40,
     ...overrides,
   };
 }

--- a/src/services/web_search.test.ts
+++ b/src/services/web_search.test.ts
@@ -30,7 +30,7 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     autonomousChatEnabled: false,
     autonomousChatMinHumanMessages: 4,
     autonomousChatActivityWindowMinutes: 20,
-    autonomousChatCooldownMinutes: 30,
+    autonomousChatCooldownMinutes: 1,
     autonomousChatReplyChance: 0.35,
     autonomousChatMaxContextMessages: 40,
     ...overrides,

--- a/src/services/web_search.test.ts
+++ b/src/services/web_search.test.ts
@@ -27,6 +27,12 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webSearchApiKey: "brave-key",
     webSearchMaxResults: 3,
     linkOpenEnabled: true,
+    autonomousChatEnabled: false,
+    autonomousChatMinHumanMessages: 4,
+    autonomousChatActivityWindowMinutes: 20,
+    autonomousChatCooldownMinutes: 30,
+    autonomousChatReplyChance: 0.35,
+    autonomousChatMaxContextMessages: 40,
     ...overrides,
   };
 }

--- a/src/services/web_search.test.ts
+++ b/src/services/web_search.test.ts
@@ -28,6 +28,7 @@ function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webSearchMaxResults: 3,
     linkOpenEnabled: true,
     autonomousChatEnabled: false,
+    autonomousChatChannelIds: ["test-channel"],
     autonomousChatMinHumanMessages: 4,
     autonomousChatActivityWindowMinutes: 20,
     autonomousChatCooldownMinutes: 1,


### PR DESCRIPTION
## Summary
- Add opt-in autonomous chat config so Haru can join active conversations without direct mentions.
- Fetch recent Discord messages per channel for scheduled context instead of relying on mention-triggered in-memory cache.
- Gate autonomous replies on recent human activity, Haru cooldown, a human message after Haru, daily token budget, and reply probability.

## Verification
- deno task check
- deno test --unstable-kv --allow-env
- deno task lint